### PR TITLE
Genericize layout code to operate on horizontal and vertical axes uniformly

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,4 +1,4 @@
-use crate::types::{GeometryChanged, Axis};
+use crate::types::{GeometryChanged, Direction};
 use crate::Node;
 
 /// The Cache stores the result of layout as well as intermediate values for each node
@@ -101,100 +101,100 @@ pub trait Cache {
     fn set_stack_last_child(&mut self, node: Self::Item, value: bool);
 
     // generic getters
-    fn width_height(&self, node: Self::Item, axis: Axis) -> f32 {
+    fn width_height(&self, node: Self::Item, axis: Direction) -> f32 {
         match axis {
-            Axis::X => self.width(node),
-            Axis::Y => self.height(node),
+            Direction::X => self.width(node),
+            Direction::Y => self.height(node),
         }
     }
-    fn posx_posy(&self, node: Self::Item, axis: Axis) -> f32 {
+    fn posx_posy(&self, node: Self::Item, axis: Direction) -> f32 {
         match axis {
-            Axis::X => self.posx(node),
-            Axis::Y => self.posy(node),
+            Direction::X => self.posx(node),
+            Direction::Y => self.posy(node),
         }
     }
-    fn left_top(&self, node: Self::Item, axis: Axis) -> f32 {
+    fn left_top(&self, node: Self::Item, axis: Direction) -> f32 {
         match axis {
-            Axis::X => self.left(node),
-            Axis::Y => self.top(node),
+            Direction::X => self.left(node),
+            Direction::Y => self.top(node),
         }
     }
-    fn right_bottom(&self, node: Self::Item, axis: Axis) -> f32 {
+    fn right_bottom(&self, node: Self::Item, axis: Direction) -> f32 {
         match axis {
-            Axis::X => self.right(node),
-            Axis::Y => self.bottom(node),
+            Direction::X => self.right(node),
+            Direction::Y => self.bottom(node),
         }
     }
-    fn new_width_height(&self, node: Self::Item, axis: Axis) -> f32 {
+    fn new_width_height(&self, node: Self::Item, axis: Direction) -> f32 {
         match axis {
-            Axis::X => self.new_width(node),
-            Axis::Y => self.new_height(node),
+            Direction::X => self.new_width(node),
+            Direction::Y => self.new_height(node),
         }
     }
-    fn child_width_height_max(&self, node: Self::Item, axis: Axis) -> f32 {
+    fn child_width_height_max(&self, node: Self::Item, axis: Direction) -> f32 {
         match axis {
-            Axis::X => self.child_width_max(node),
-            Axis::Y => self.child_height_max(node),
+            Direction::X => self.child_width_max(node),
+            Direction::Y => self.child_height_max(node),
         }
     }
-    fn child_width_height_sum(&self, node: Self::Item, axis: Axis) -> f32 {
+    fn child_width_height_sum(&self, node: Self::Item, axis: Direction) -> f32 {
         match axis {
-            Axis::X => self.child_width_sum(node),
-            Axis::Y => self.child_height_sum(node),
+            Direction::X => self.child_width_sum(node),
+            Direction::Y => self.child_height_sum(node),
         }
     }
-    fn grid_row_col_max(&self, node: Self::Item, axis: Axis) -> f32 {
+    fn grid_row_col_max(&self, node: Self::Item, axis: Direction) -> f32 {
         match axis {
-            Axis::X => self.grid_row_max(node),
-            Axis::Y => self.grid_col_max(node),
+            Direction::X => self.grid_row_max(node),
+            Direction::Y => self.grid_col_max(node),
         }
     }
-    fn set_width_height(&mut self, node: Self::Item, value: f32, axis: Axis) {
+    fn set_width_height(&mut self, node: Self::Item, value: f32, axis: Direction) {
         match axis {
-            Axis::X => self.set_width(node, value),
-            Axis::Y => self.set_height(node, value),
+            Direction::X => self.set_width(node, value),
+            Direction::Y => self.set_height(node, value),
         }
     }
-    fn set_posx_posy(&mut self, node: Self::Item, value: f32, axis: Axis) {
+    fn set_posx_posy(&mut self, node: Self::Item, value: f32, axis: Direction) {
         match axis {
-            Axis::X => self.set_posx(node, value),
-            Axis::Y => self.set_posy(node, value),
+            Direction::X => self.set_posx(node, value),
+            Direction::Y => self.set_posy(node, value),
         }
     }
-    fn set_left_top(&mut self, node: Self::Item, value: f32, axis: Axis) {
+    fn set_left_top(&mut self, node: Self::Item, value: f32, axis: Direction) {
         match axis {
-            Axis::X => self.set_left(node, value),
-            Axis::Y => self.set_top(node, value),
+            Direction::X => self.set_left(node, value),
+            Direction::Y => self.set_top(node, value),
         }
     }
-    fn set_right_bottom(&mut self, node: Self::Item, value: f32, axis: Axis) {
+    fn set_right_bottom(&mut self, node: Self::Item, value: f32, axis: Direction) {
         match axis {
-            Axis::X => self.set_right(node, value),
-            Axis::Y => self.set_bottom(node, value),
+            Direction::X => self.set_right(node, value),
+            Direction::Y => self.set_bottom(node, value),
         }
     }
-    fn set_new_width_height(&mut self, node: Self::Item, value: f32, axis: Axis) {
+    fn set_new_width_height(&mut self, node: Self::Item, value: f32, axis: Direction) {
         match axis {
-            Axis::X => self.set_new_width(node, value),
-            Axis::Y => self.set_new_height(node, value),
+            Direction::X => self.set_new_width(node, value),
+            Direction::Y => self.set_new_height(node, value),
         }
     }
-    fn set_child_width_height_max(&mut self, node: Self::Item, value: f32, axis: Axis) {
+    fn set_child_width_height_max(&mut self, node: Self::Item, value: f32, axis: Direction) {
         match axis {
-            Axis::X => self.set_child_width_max(node, value),
-            Axis::Y => self.set_child_height_max(node, value),
+            Direction::X => self.set_child_width_max(node, value),
+            Direction::Y => self.set_child_height_max(node, value),
         }
     }
-    fn set_child_width_height_sum(&mut self, node: Self::Item, value: f32, axis: Axis) {
+    fn set_child_width_height_sum(&mut self, node: Self::Item, value: f32, axis: Direction) {
         match axis {
-            Axis::X => self.set_child_width_sum(node, value),
-            Axis::Y => self.set_child_height_sum(node, value),
+            Direction::X => self.set_child_width_sum(node, value),
+            Direction::Y => self.set_child_height_sum(node, value),
         }
     }
-    fn set_grid_row_col_max(&mut self, node: Self::Item, value: f32, axis: Axis) {
+    fn set_grid_row_col_max(&mut self, node: Self::Item, value: f32, axis: Direction) {
         match axis {
-            Axis::X => self.set_grid_row_max(node, value),
-            Axis::Y => self.set_grid_col_max(node, value),
+            Direction::X => self.set_grid_row_max(node, value),
+            Direction::Y => self.set_grid_col_max(node, value),
         }
     }
 }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,5 +1,5 @@
 use crate::types::{GeometryChanged, Direction};
-use crate::Node;
+use crate::{LayoutType, Node};
 
 /// The Cache stores the result of layout as well as intermediate values for each node
 pub trait Cache {
@@ -149,6 +149,39 @@ pub trait Cache {
             Direction::Y => self.grid_col_max(node),
         }
     }
+    fn child_width_height_column(&self, node: Self::Item, axis: Direction) -> f32 {
+        match axis {
+            Direction::X => self.child_width_max(node),
+            Direction::Y => self.child_height_sum(node),
+        }
+    }
+    fn child_width_height_row(&self, node: Self::Item, axis: Direction) -> f32 {
+        match axis {
+            Direction::X => self.child_width_sum(node),
+            Direction::Y => self.child_height_max(node),
+        }
+    }
+    fn child_width_height_layout(&self, node: Self::Item, dir: Direction, layout: LayoutType) -> f32 {
+        match layout {
+            LayoutType::Column => self.child_width_height_column(node, dir),
+            LayoutType::Row => self.child_width_height_row(node, dir),
+            LayoutType::Grid => self.grid_row_col_max(node, dir),
+        }
+    }
+    fn h_v_free_space(&self, node: Self::Item, dir: Direction) -> f32 {
+        match dir {
+            Direction::X => self.horizontal_free_space(node),
+            Direction::Y => self.vertical_free_space(node),
+        }
+    }
+    fn h_v_stretch_sum(&self, node: Self::Item, dir: Direction) -> f32 {
+        match dir {
+            Direction::X => self.horizontal_stretch_sum(node),
+            Direction::Y => self.vertical_stretch_sum(node),
+        }
+    }
+
+    // generic setters
     fn set_width_height(&mut self, node: Self::Item, value: f32, axis: Direction) {
         match axis {
             Direction::X => self.set_width(node, value),
@@ -197,4 +230,17 @@ pub trait Cache {
             Direction::Y => self.set_grid_col_max(node, value),
         }
     }
+    fn set_h_v_free_space(&mut self, node: Self::Item, value: f32, dir: Direction) {
+        match dir {
+            Direction::X => self.set_horizontal_free_space(node, value),
+            Direction::Y => self.set_vertical_free_space(node, value),
+        }
+    }
+    fn set_h_v_stretch_sum(&mut self, node: Self::Item, value: f32, dir: Direction) {
+        match dir {
+            Direction::X => self.set_horizontal_stretch_sum(node, value),
+            Direction::Y => self.set_vertical_stretch_sum(node, value),
+        }
+    }
+
 }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,4 +1,4 @@
-use crate::types::GeometryChanged;
+use crate::types::{GeometryChanged, Axis};
 use crate::Node;
 
 /// The Cache stores the result of layout as well as intermediate values for each node
@@ -99,4 +99,102 @@ pub trait Cache {
     fn set_stack_first_child(&mut self, node: Self::Item, value: bool);
     fn stack_last_child(&self, node: Self::Item) -> bool;
     fn set_stack_last_child(&mut self, node: Self::Item, value: bool);
+
+    // generic getters
+    fn width_height(&self, node: Self::Item, axis: Axis) -> f32 {
+        match axis {
+            Axis::X => self.width(node),
+            Axis::Y => self.height(node),
+        }
+    }
+    fn posx_posy(&self, node: Self::Item, axis: Axis) -> f32 {
+        match axis {
+            Axis::X => self.posx(node),
+            Axis::Y => self.posy(node),
+        }
+    }
+    fn left_top(&self, node: Self::Item, axis: Axis) -> f32 {
+        match axis {
+            Axis::X => self.left(node),
+            Axis::Y => self.top(node),
+        }
+    }
+    fn right_bottom(&self, node: Self::Item, axis: Axis) -> f32 {
+        match axis {
+            Axis::X => self.right(node),
+            Axis::Y => self.bottom(node),
+        }
+    }
+    fn new_width_height(&self, node: Self::Item, axis: Axis) -> f32 {
+        match axis {
+            Axis::X => self.new_width(node),
+            Axis::Y => self.new_height(node),
+        }
+    }
+    fn child_width_height_max(&self, node: Self::Item, axis: Axis) -> f32 {
+        match axis {
+            Axis::X => self.child_width_max(node),
+            Axis::Y => self.child_height_max(node),
+        }
+    }
+    fn child_width_height_sum(&self, node: Self::Item, axis: Axis) -> f32 {
+        match axis {
+            Axis::X => self.child_width_sum(node),
+            Axis::Y => self.child_height_sum(node),
+        }
+    }
+    fn grid_row_col_max(&self, node: Self::Item, axis: Axis) -> f32 {
+        match axis {
+            Axis::X => self.grid_row_max(node),
+            Axis::Y => self.grid_col_max(node),
+        }
+    }
+    fn set_width_height(&mut self, node: Self::Item, value: f32, axis: Axis) {
+        match axis {
+            Axis::X => self.set_width(node, value),
+            Axis::Y => self.set_height(node, value),
+        }
+    }
+    fn set_posx_posy(&mut self, node: Self::Item, value: f32, axis: Axis) {
+        match axis {
+            Axis::X => self.set_posx(node, value),
+            Axis::Y => self.set_posy(node, value),
+        }
+    }
+    fn set_left_top(&mut self, node: Self::Item, value: f32, axis: Axis) {
+        match axis {
+            Axis::X => self.set_left(node, value),
+            Axis::Y => self.set_top(node, value),
+        }
+    }
+    fn set_right_bottom(&mut self, node: Self::Item, value: f32, axis: Axis) {
+        match axis {
+            Axis::X => self.set_right(node, value),
+            Axis::Y => self.set_bottom(node, value),
+        }
+    }
+    fn set_new_width_height(&mut self, node: Self::Item, value: f32, axis: Axis) {
+        match axis {
+            Axis::X => self.set_new_width(node, value),
+            Axis::Y => self.set_new_height(node, value),
+        }
+    }
+    fn set_child_width_height_max(&mut self, node: Self::Item, value: f32, axis: Axis) {
+        match axis {
+            Axis::X => self.set_child_width_max(node, value),
+            Axis::Y => self.set_child_height_max(node, value),
+        }
+    }
+    fn set_child_width_height_sum(&mut self, node: Self::Item, value: f32, axis: Axis) {
+        match axis {
+            Axis::X => self.set_child_width_sum(node, value),
+            Axis::Y => self.set_child_height_sum(node, value),
+        }
+    }
+    fn set_grid_row_col_max(&mut self, node: Self::Item, value: f32, axis: Axis) {
+        match axis {
+            Axis::X => self.set_grid_row_max(node, value),
+            Axis::Y => self.set_grid_col_max(node, value),
+        }
+    }
 }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,4 +1,4 @@
-use crate::types::{GeometryChanged, Direction};
+use crate::types::{Direction, GeometryChanged};
 use crate::{LayoutType, Node};
 
 /// The Cache stores the result of layout as well as intermediate values for each node
@@ -101,43 +101,43 @@ pub trait Cache {
     fn set_stack_last_child(&mut self, node: Self::Item, value: bool);
 
     // generic getters
-    fn width_height(&self, node: Self::Item, axis: Direction) -> f32 {
+    fn size(&self, node: Self::Item, axis: Direction) -> f32 {
         match axis {
             Direction::X => self.width(node),
             Direction::Y => self.height(node),
         }
     }
-    fn posx_posy(&self, node: Self::Item, axis: Direction) -> f32 {
+    fn pos(&self, node: Self::Item, axis: Direction) -> f32 {
         match axis {
             Direction::X => self.posx(node),
             Direction::Y => self.posy(node),
         }
     }
-    fn left_top(&self, node: Self::Item, axis: Direction) -> f32 {
+    fn before(&self, node: Self::Item, axis: Direction) -> f32 {
         match axis {
             Direction::X => self.left(node),
             Direction::Y => self.top(node),
         }
     }
-    fn right_bottom(&self, node: Self::Item, axis: Direction) -> f32 {
+    fn after(&self, node: Self::Item, axis: Direction) -> f32 {
         match axis {
             Direction::X => self.right(node),
             Direction::Y => self.bottom(node),
         }
     }
-    fn new_width_height(&self, node: Self::Item, axis: Direction) -> f32 {
+    fn new_size(&self, node: Self::Item, axis: Direction) -> f32 {
         match axis {
             Direction::X => self.new_width(node),
             Direction::Y => self.new_height(node),
         }
     }
-    fn child_width_height_max(&self, node: Self::Item, axis: Direction) -> f32 {
+    fn child_size_max(&self, node: Self::Item, axis: Direction) -> f32 {
         match axis {
             Direction::X => self.child_width_max(node),
             Direction::Y => self.child_height_max(node),
         }
     }
-    fn child_width_height_sum(&self, node: Self::Item, axis: Direction) -> f32 {
+    fn child_size_sum(&self, node: Self::Item, axis: Direction) -> f32 {
         match axis {
             Direction::X => self.child_width_sum(node),
             Direction::Y => self.child_height_sum(node),
@@ -149,32 +149,32 @@ pub trait Cache {
             Direction::Y => self.grid_col_max(node),
         }
     }
-    fn child_width_height_column(&self, node: Self::Item, axis: Direction) -> f32 {
+    fn child_size_column(&self, node: Self::Item, axis: Direction) -> f32 {
         match axis {
             Direction::X => self.child_width_max(node),
             Direction::Y => self.child_height_sum(node),
         }
     }
-    fn child_width_height_row(&self, node: Self::Item, axis: Direction) -> f32 {
+    fn child_size_row(&self, node: Self::Item, axis: Direction) -> f32 {
         match axis {
             Direction::X => self.child_width_sum(node),
             Direction::Y => self.child_height_max(node),
         }
     }
-    fn child_width_height_layout(&self, node: Self::Item, dir: Direction, layout: LayoutType) -> f32 {
+    fn child_size_layout(&self, node: Self::Item, dir: Direction, layout: LayoutType) -> f32 {
         match layout {
-            LayoutType::Column => self.child_width_height_column(node, dir),
-            LayoutType::Row => self.child_width_height_row(node, dir),
+            LayoutType::Column => self.child_size_column(node, dir),
+            LayoutType::Row => self.child_size_row(node, dir),
             LayoutType::Grid => self.grid_row_col_max(node, dir),
         }
     }
-    fn h_v_free_space(&self, node: Self::Item, dir: Direction) -> f32 {
+    fn free_space(&self, node: Self::Item, dir: Direction) -> f32 {
         match dir {
             Direction::X => self.horizontal_free_space(node),
             Direction::Y => self.vertical_free_space(node),
         }
     }
-    fn h_v_stretch_sum(&self, node: Self::Item, dir: Direction) -> f32 {
+    fn stretch_sum(&self, node: Self::Item, dir: Direction) -> f32 {
         match dir {
             Direction::X => self.horizontal_stretch_sum(node),
             Direction::Y => self.vertical_stretch_sum(node),
@@ -182,43 +182,43 @@ pub trait Cache {
     }
 
     // generic setters
-    fn set_width_height(&mut self, node: Self::Item, value: f32, axis: Direction) {
+    fn set_size(&mut self, node: Self::Item, value: f32, axis: Direction) {
         match axis {
             Direction::X => self.set_width(node, value),
             Direction::Y => self.set_height(node, value),
         }
     }
-    fn set_posx_posy(&mut self, node: Self::Item, value: f32, axis: Direction) {
+    fn set_pos(&mut self, node: Self::Item, value: f32, axis: Direction) {
         match axis {
             Direction::X => self.set_posx(node, value),
             Direction::Y => self.set_posy(node, value),
         }
     }
-    fn set_left_top(&mut self, node: Self::Item, value: f32, axis: Direction) {
+    fn set_before(&mut self, node: Self::Item, value: f32, axis: Direction) {
         match axis {
             Direction::X => self.set_left(node, value),
             Direction::Y => self.set_top(node, value),
         }
     }
-    fn set_right_bottom(&mut self, node: Self::Item, value: f32, axis: Direction) {
+    fn set_after(&mut self, node: Self::Item, value: f32, axis: Direction) {
         match axis {
             Direction::X => self.set_right(node, value),
             Direction::Y => self.set_bottom(node, value),
         }
     }
-    fn set_new_width_height(&mut self, node: Self::Item, value: f32, axis: Direction) {
+    fn set_new_size(&mut self, node: Self::Item, value: f32, axis: Direction) {
         match axis {
             Direction::X => self.set_new_width(node, value),
             Direction::Y => self.set_new_height(node, value),
         }
     }
-    fn set_child_width_height_max(&mut self, node: Self::Item, value: f32, axis: Direction) {
+    fn set_child_size_max(&mut self, node: Self::Item, value: f32, axis: Direction) {
         match axis {
             Direction::X => self.set_child_width_max(node, value),
             Direction::Y => self.set_child_height_max(node, value),
         }
     }
-    fn set_child_width_height_sum(&mut self, node: Self::Item, value: f32, axis: Direction) {
+    fn set_child_size_sum(&mut self, node: Self::Item, value: f32, axis: Direction) {
         match axis {
             Direction::X => self.set_child_width_sum(node, value),
             Direction::Y => self.set_child_height_sum(node, value),
@@ -230,17 +230,16 @@ pub trait Cache {
             Direction::Y => self.set_grid_col_max(node, value),
         }
     }
-    fn set_h_v_free_space(&mut self, node: Self::Item, value: f32, dir: Direction) {
+    fn set_free_space(&mut self, node: Self::Item, value: f32, dir: Direction) {
         match dir {
             Direction::X => self.set_horizontal_free_space(node, value),
             Direction::Y => self.set_vertical_free_space(node, value),
         }
     }
-    fn set_h_v_stretch_sum(&mut self, node: Self::Item, value: f32, dir: Direction) {
+    fn set_stretch_sum(&mut self, node: Self::Item, value: f32, dir: Direction) {
         match dir {
             Direction::X => self.set_horizontal_stretch_sum(node, value),
             Direction::Y => self.set_vertical_stretch_sum(node, value),
         }
     }
-
 }

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -111,985 +111,14 @@ pub fn layout<'a, C, H>(
         }
 
         let parent_layout_type = parent.layout_type(store).unwrap_or_default();
-        let child_left = parent.child_left(store).unwrap_or_default();
-        let child_right = parent.child_right(store).unwrap_or_default();
-        let child_top = parent.child_top(store).unwrap_or_default();
-        let child_bottom = parent.child_bottom(store).unwrap_or_default();
-
-        let row_between = parent.row_between(store).unwrap_or_default();
-        let col_between = parent.col_between(store).unwrap_or_default();
-
-        let mut parent_width = cache.new_width(parent);
-        let mut parent_height = cache.new_height(parent);
-
-        let parent_border_left =
-            parent.border_left(store).unwrap_or_default().value_or(parent_width, 0.0);
-        let parent_border_right =
-            parent.border_right(store).unwrap_or_default().value_or(parent_width, 0.0);
-        let parent_border_top =
-            parent.border_top(store).unwrap_or_default().value_or(parent_width, 0.0);
-        let parent_border_bottom =
-            parent.border_bottom(store).unwrap_or_default().value_or(parent_width, 0.0);
-
-        parent_width -= parent_border_left + parent_border_right;
-        parent_height -= parent_border_top + parent_border_bottom;
-
-        let mut parent_horizontal_free_space = parent_width;
-        let mut parent_vertical_free_space = parent_height;
-        let mut parent_horizontal_stretch_sum = 0.0;
-        let mut parent_vertical_stretch_sum = 0.0;
 
         match parent_layout_type {
             LayoutType::Row | LayoutType::Column => {
-                let mut horizontal_axis =
-                    SmallVec::<[ComputedData<<H as Hierarchy>::Item>; 3]>::new();
-                let mut vertical_axis =
-                    SmallVec::<[ComputedData<<H as Hierarchy>::Item>; 3]>::new();
-
-                // ////////////////////////////////
-                // Calculate inflexible children //
-                ///////////////////////////////////
-                for node in hierarchy.child_iter(parent) {
-                    let visible = cache.visible(node);
-                    if !visible {
-                        continue;
-                    }
-
-                    let layout_type = node.layout_type(store).unwrap_or_default();
-
-                    let mut left = node.left(store).unwrap_or_default();
-                    let mut right = node.right(store).unwrap_or_default();
-                    let mut top = node.top(store).unwrap_or_default();
-                    let mut bottom = node.bottom(store).unwrap_or_default();
-
-                    let min_left = node
-                        .min_left(store)
-                        .unwrap_or_default()
-                        .value_or(parent_width, -f32::MAX);
-                    let max_left = node
-                        .max_left(store)
-                        .unwrap_or_default()
-                        .value_or(parent_width, f32::MAX);
-                    let min_right = node
-                        .min_right(store)
-                        .unwrap_or_default()
-                        .value_or(parent_width, -f32::MAX);
-                    let max_right = node
-                        .max_right(store)
-                        .unwrap_or_default()
-                        .value_or(parent_width, f32::MAX);
-                    let min_top = node
-                        .min_top(store)
-                        .unwrap_or_default()
-                        .value_or(parent_width, -f32::MAX);
-                    let max_top = node
-                        .max_top(store)
-                        .unwrap_or_default()
-                        .value_or(parent_width, f32::MAX);
-                    let min_bottom = node
-                        .min_bottom(store)
-                        .unwrap_or_default()
-                        .value_or(parent_width, -f32::MAX);
-                    let max_bottom = node
-                        .max_bottom(store)
-                        .unwrap_or_default()
-                        .value_or(parent_width, f32::MAX);
-
-                    let width = node.width(store).unwrap_or(Units::Stretch(1.0));
-                    let height = node.height(store).unwrap_or(Units::Stretch(1.0));
-
-                    // TODO - This could be cached during up phase because it shouldn't change between up phase and down phase
-                    let mut min_width = node.min_width(store).unwrap_or_default().value_or(
-                        parent_width,
-                        match layout_type {
-                            LayoutType::Column => cache.child_width_max(node),
-                            LayoutType::Row => cache.child_width_sum(node),
-                            LayoutType::Grid => cache.grid_row_max(node),
-                        },
-                    );
-                    min_width = min_width.clamp(0.0, f32::MAX);
-
-                    let mut max_width = node
-                        .max_width(store)
-                        .unwrap_or_default()
-                        .value_or(parent_width, f32::MAX);
-                    max_width = max_width.max(min_width);
-
-                    // This could be cached during up phase because it shouldn't change between up phase and down phase
-                    let mut min_height = node.min_height(store).unwrap_or_default().value_or(
-                        parent_height,
-                        match layout_type {
-                            LayoutType::Column => cache.child_height_sum(node),
-                            LayoutType::Row => cache.child_height_max(node),
-                            LayoutType::Grid => cache.grid_col_max(node),
-                        },
-                    );
-                    min_height = min_height.clamp(0.0, f32::MAX);
-
-                    let mut max_height = node
-                        .max_height(store)
-                        .unwrap_or_default()
-                        .value_or(parent_height, f32::MAX);
-                    max_height = max_height.max(min_height);
-
-                    let border_left =
-                        node.border_left(store).unwrap_or_default().value_or(parent_width, 0.0);
-                    let border_right =
-                        node.border_right(store).unwrap_or_default().value_or(parent_width, 0.0);
-                    let border_top =
-                        node.border_top(store).unwrap_or_default().value_or(parent_width, 0.0);
-                    let border_bottom =
-                        node.border_bottom(store).unwrap_or_default().value_or(parent_width, 0.0);
-
-                    let position_type = node.position_type(store).unwrap_or_default();
-
-                    // Parent overrides
-                    match parent_layout_type {
-                        LayoutType::Column => {
-                            if top == Units::Auto {
-                                if cache.stack_first_child(node) {
-                                    top = child_top;
-                                } else {
-                                    top = row_between;
-                                }
-                            }
-
-                            if bottom == Units::Auto {
-                                if cache.stack_last_child(node) {
-                                    bottom = child_bottom;
-                                }
-                            }
-
-                            if left == Units::Auto {
-                                left = child_left;
-                            }
-
-                            if right == Units::Auto {
-                                right = child_right;
-                            }
-                        }
-
-                        LayoutType::Row => {
-                            if left == Units::Auto {
-                                if cache.stack_first_child(node) {
-                                    left = child_left;
-                                } else {
-                                    left = col_between;
-                                }
-                            }
-
-                            if right == Units::Auto {
-                                if cache.stack_last_child(node) {
-                                    right = child_right;
-                                }
-                            }
-
-                            if top == Units::Auto {
-                                top = child_top;
-                            }
-
-                            if bottom == Units::Auto {
-                                bottom = child_bottom;
-                            }
-                        }
-
-                        _ => {}
-                    }
-
-                    let mut new_left = 0.0;
-                    let mut new_width = 0.0;
-                    let mut new_right = 0.0;
-
-                    let mut new_top = 0.0;
-                    let mut new_height = 0.0;
-                    let mut new_bottom = 0.0;
-
-                    let mut horizontal_stretch_sum = 0.0;
-                    let mut vertical_stretch_sum = 0.0;
-
-                    let mut horizontal_free_space = parent_width;
-                    let mut vertical_free_space = parent_height;
-
-                    // TODO - replace all these match' with a function
-                    match left {
-                        Units::Pixels(val) => {
-                            new_left = val.clamp(min_left, max_left);
-                            horizontal_free_space -= new_left;
-                        }
-
-                        Units::Percentage(val) => {
-                            new_left = (val / 100.0) * parent_width;
-                            new_left = new_left.clamp(min_left, max_left);
-                            horizontal_free_space -= new_left;
-                        }
-
-                        Units::Stretch(val) => {
-                            horizontal_stretch_sum += val;
-                            horizontal_axis.push(ComputedData {
-                                node: node.clone(),
-                                value: val,
-                                min: min_left,
-                                max: max_left,
-                                axis: Axis::Before,
-                            });
-                        }
-
-                        _ => {}
-                    }
-
-                    match width {
-                        Units::Pixels(val) => {
-                            new_width = val.clamp(min_width, max_width);
-                            horizontal_free_space -= new_width;
-                        }
-
-                        Units::Percentage(val) => {
-                            new_width = (val / 100.0) * parent_width;
-                            new_width = new_width.clamp(min_width, max_width);
-                            horizontal_free_space -= new_width;
-                        }
-
-                        Units::Stretch(val) => {
-                            horizontal_stretch_sum += val;
-                            horizontal_axis.push(ComputedData {
-                                node: node.clone(),
-                                value: val,
-                                min: min_width,
-                                max: max_width,
-                                axis: Axis::Size,
-                            });
-                        }
-
-                        Units::Auto => {
-                            match layout_type {
-                                LayoutType::Column => {
-                                    new_width = cache.child_width_max(node);
-                                }
-
-                                LayoutType::Row | LayoutType::Grid => {
-                                    new_width = cache.child_width_sum(node);
-                                }
-                            }
-
-                            new_width = new_width.clamp(min_width, max_width);
-
-                            new_width += border_left + border_right;
-                            horizontal_free_space -= new_width;
-                        }
-                    }
-
-                    match right {
-                        Units::Pixels(val) => {
-                            new_right = val.clamp(min_right, max_right);
-                            horizontal_free_space -= new_right;
-                        }
-
-                        Units::Percentage(val) => {
-                            new_right = (val / 100.0) * parent_width;
-                            new_right = new_right.clamp(min_right, max_right);
-                            horizontal_free_space -= new_right;
-                        }
-
-                        Units::Stretch(val) => {
-                            horizontal_stretch_sum += val;
-                            horizontal_axis.push(ComputedData {
-                                node: node.clone(),
-                                value: val,
-                                min: min_right,
-                                max: max_right,
-                                axis: Axis::After,
-                            });
-                        }
-
-                        _ => {}
-                    }
-
-                    match top {
-                        Units::Pixels(val) => {
-                            new_top = val.clamp(min_top, max_top);
-                            vertical_free_space -= new_top;
-                        }
-
-                        Units::Percentage(val) => {
-                            new_top = (val / 100.0) * parent_height;
-                            new_top = new_top.clamp(min_top, max_top);
-                            vertical_free_space -= new_top;
-                        }
-
-                        Units::Stretch(val) => {
-                            vertical_stretch_sum += val;
-                            vertical_axis.push(ComputedData {
-                                node: node.clone(),
-                                value: val,
-                                min: min_top,
-                                max: max_top,
-                                axis: Axis::Before,
-                            });
-                        }
-
-                        _ => {}
-                    }
-
-                    match height {
-                        Units::Pixels(val) => {
-                            new_height = val.clamp(min_height, max_height);
-                            vertical_free_space -= new_height;
-                        }
-
-                        Units::Percentage(val) => {
-                            new_height = (val / 100.0) * parent_height;
-                            new_height = new_height.clamp(min_height, max_height);
-                            vertical_free_space -= new_height;
-                        }
-
-                        Units::Stretch(val) => {
-                            vertical_stretch_sum += val;
-                            vertical_axis.push(ComputedData {
-                                node: node.clone(),
-                                value: val,
-                                min: min_height,
-                                max: max_height,
-                                axis: Axis::Size,
-                            });
-                        }
-
-                        Units::Auto => {
-                            match layout_type {
-                                LayoutType::Column | LayoutType::Grid => {
-                                    new_height = cache.child_height_sum(node);
-                                }
-
-                                LayoutType::Row => {
-                                    new_height = cache.child_height_max(node);
-                                }
-                            }
-
-                            new_height = new_height.clamp(min_height, max_height);
-
-                            new_height += border_top + border_bottom;
-                            vertical_free_space -= new_height;
-                        }
-                    }
-
-                    match bottom {
-                        Units::Pixels(val) => {
-                            new_bottom = val.clamp(min_bottom, max_bottom);
-                            vertical_free_space -= val;
-                        }
-
-                        Units::Percentage(val) => {
-                            new_bottom = (val / 100.0) * parent_height;
-                            new_bottom = new_bottom.clamp(min_bottom, max_bottom);
-                            vertical_free_space -= new_bottom;
-                        }
-
-                        Units::Stretch(val) => {
-                            vertical_stretch_sum += val;
-                            vertical_axis.push(ComputedData {
-                                node: node.clone(),
-                                value: val,
-                                min: min_bottom,
-                                max: max_bottom,
-                                axis: Axis::After,
-                            });
-                        }
-
-                        _ => {}
-                    }
-
-                    cache.set_new_width(node, new_width);
-                    cache.set_new_height(node, new_height);
-                    cache.set_left(node, new_left);
-                    cache.set_right(node, new_right);
-                    cache.set_top(node, new_top);
-                    cache.set_bottom(node, new_bottom);
-
-                    if position_type == PositionType::ParentDirected {
-                        parent_vertical_free_space -= parent_height - vertical_free_space;
-                        parent_horizontal_free_space -= parent_width - horizontal_free_space;
-                        parent_vertical_stretch_sum += vertical_stretch_sum;
-                        parent_horizontal_stretch_sum += horizontal_stretch_sum;
-                    }
-
-                    cache.set_horizontal_free_space(node, horizontal_free_space);
-                    cache.set_horizontal_stretch_sum(node, horizontal_stretch_sum);
-                    cache.set_vertical_free_space(node, vertical_free_space);
-                    cache.set_vertical_stretch_sum(node, vertical_stretch_sum);
-                }
-
-                if parent_horizontal_stretch_sum == 0.0 {
-                    parent_horizontal_stretch_sum = 1.0;
-                }
-
-                if parent_vertical_stretch_sum == 0.0 {
-                    parent_vertical_stretch_sum = 1.0;
-                }
-
-                // Sort the stretch elements in each axis by the maximum size
-                horizontal_axis.sort_by(|a, b| b.min.partial_cmp(&a.min).unwrap());
-                vertical_axis.sort_by(|a, b| b.min.partial_cmp(&a.min).unwrap());
-
-                let mut horizontal_stretch_sum = 0.0;
-                let mut horizontal_free_space = 0.0;
-                let mut vertical_stretch_sum = 0.0;
-                let mut vertical_free_space = 0.0;
-
-                /////////////////////////////////////////
-                // Calculate flexible Row space & size //
-                /////////////////////////////////////////
-                for computed_data in horizontal_axis.iter() {
-                    let node = computed_data.node.clone();
-
-                    let position_type = node.position_type(store).unwrap_or_default();
-
-                    match position_type {
-                        PositionType::SelfDirected => {
-                            horizontal_free_space = cache.horizontal_free_space(node);
-                            horizontal_stretch_sum = cache.horizontal_stretch_sum(node);
-                        }
-
-                        PositionType::ParentDirected => match parent_layout_type {
-                            LayoutType::Row => {
-                                horizontal_stretch_sum = parent_horizontal_stretch_sum;
-                                horizontal_free_space = parent_horizontal_free_space;
-                            }
-
-                            LayoutType::Column => {
-                                horizontal_free_space = cache.horizontal_free_space(node);
-                                horizontal_stretch_sum = cache.horizontal_stretch_sum(node);
-                            }
-
-                            _ => {}
-                        },
-                    }
-
-                    // Prevent a divide by zero when the stretch sum is 0
-                    if horizontal_stretch_sum == 0.0 {
-                        horizontal_stretch_sum = 1.0;
-                    }
-
-                    // Compute the new left/width/height based on free space, stretch factor, and stretch_sum
-                    #[cfg(feature = "rounding")]
-                    let mut new_value = (horizontal_free_space * computed_data.value
-                        / horizontal_stretch_sum)
-                        .round();
-                    #[cfg(not(feature = "rounding"))]
-                    let mut new_value =
-                        horizontal_free_space * computed_data.value / horizontal_stretch_sum;
-
-                    // Clamp the new left/width/right to be between min_ left/width/right and max_ left/width/right
-                    new_value = new_value.clamp(computed_data.min, computed_data.max);
-
-                    // Could perhaps replace this with a closure
-                    match computed_data.axis {
-                        Axis::Before => {
-                            cache.set_left(node, new_value);
-                        }
-
-                        Axis::Size => {
-                            cache.set_new_width(node, new_value);
-                        }
-
-                        Axis::After => {
-                            cache.set_right(node, new_value);
-                        }
-                    }
-
-                    match position_type {
-                        PositionType::SelfDirected => {
-                            cache.set_horizontal_stretch_sum(
-                                node,
-                                horizontal_stretch_sum - computed_data.value,
-                            );
-                            cache
-                                .set_horizontal_free_space(node, horizontal_free_space - new_value);
-                        }
-
-                        PositionType::ParentDirected => {
-                            match parent_layout_type {
-                                LayoutType::Column => {
-                                    cache.set_horizontal_stretch_sum(
-                                        node,
-                                        horizontal_stretch_sum - computed_data.value,
-                                    );
-                                    cache.set_horizontal_free_space(
-                                        node,
-                                        horizontal_free_space - new_value,
-                                    );
-                                }
-
-                                LayoutType::Row => {
-                                    parent_horizontal_free_space -= new_value;
-                                    parent_horizontal_stretch_sum -= computed_data.value;
-                                }
-
-                                _ => {}
-                            };
-                        }
-                    }
-                }
-
-                ////////////////////////////////////////////
-                // Calculate flexible Column space & size //
-                ////////////////////////////////////////////
-                for computed_data in vertical_axis.iter() {
-                    let node = computed_data.node.clone();
-
-                    let position_type = node.position_type(store).unwrap_or_default();
-
-                    match position_type {
-                        PositionType::SelfDirected => {
-                            vertical_free_space = cache.vertical_free_space(node);
-                            vertical_stretch_sum = cache.vertical_stretch_sum(node);
-                        }
-
-                        PositionType::ParentDirected => match parent_layout_type {
-                            LayoutType::Column => {
-                                vertical_stretch_sum = parent_vertical_stretch_sum;
-                                vertical_free_space = parent_vertical_free_space;
-                            }
-
-                            LayoutType::Row => {
-                                vertical_free_space = cache.vertical_free_space(node);
-                                vertical_stretch_sum = cache.vertical_stretch_sum(node);
-                            }
-
-                            _ => {}
-                        },
-                    }
-
-                    if vertical_stretch_sum == 0.0 {
-                        vertical_stretch_sum = 1.0;
-                    }
-
-                    #[cfg(feature = "rounding")]
-                    let mut new_value =
-                        (vertical_free_space * computed_data.value / vertical_stretch_sum).round();
-                    #[cfg(not(feature = "rounding"))]
-                    let mut new_value =
-                        vertical_free_space * computed_data.value / vertical_stretch_sum;
-
-                    new_value = new_value.clamp(computed_data.min, computed_data.max);
-
-                    match computed_data.axis {
-                        Axis::Before => {
-                            cache.set_top(node, new_value);
-                        }
-
-                        Axis::Size => {
-                            cache.set_new_height(node, new_value);
-                        }
-
-                        Axis::After => {
-                            cache.set_bottom(node, new_value);
-                        }
-                    }
-
-                    match position_type {
-                        PositionType::SelfDirected => {
-                            cache.set_vertical_stretch_sum(
-                                node,
-                                vertical_stretch_sum - computed_data.value,
-                            );
-                            cache.set_vertical_free_space(node, vertical_free_space - new_value);
-                        }
-
-                        PositionType::ParentDirected => {
-                            match parent_layout_type {
-                                LayoutType::Row => {
-                                    cache.set_vertical_stretch_sum(
-                                        node,
-                                        vertical_stretch_sum - computed_data.value,
-                                    );
-                                    cache.set_vertical_free_space(
-                                        node,
-                                        vertical_free_space - new_value,
-                                    );
-                                }
-
-                                LayoutType::Column => {
-                                    parent_vertical_free_space -= new_value;
-                                    parent_vertical_stretch_sum -= computed_data.value;
-                                }
-
-                                _ => {}
-                            };
-                        }
-                    }
-                }
-
-                let mut current_posx = 0.0;
-                let mut current_posy = 0.0;
-
-                let parent_posx = cache.posx(parent) + parent_border_left;
-                let parent_posy = cache.posy(parent) + parent_border_top;
-
-                ///////////////////////
-                // Position Children //
-                ///////////////////////
-                for node in hierarchy.child_iter(parent) {
-                    let visible = cache.visible(node);
-                    if !visible {
-                        continue;
-                    }
-
-                    let left = cache.left(node);
-                    let right = cache.right(node);
-                    let top = cache.top(node);
-                    let bottom = cache.bottom(node);
-
-                    let new_width = cache.new_width(node);
-                    let new_height = cache.new_height(node);
-
-                    let position_type = node.position_type(store).unwrap_or_default();
-
-                    let (new_posx, new_posy) = match position_type {
-                        PositionType::SelfDirected => (parent_posx + left, parent_posy + top),
-
-                        PositionType::ParentDirected => {
-                            let new_posx = parent_posx + current_posx + left;
-                            let new_posy = parent_posy + current_posy + top;
-
-                            match parent_layout_type {
-                                LayoutType::Column => {
-                                    current_posy += top + new_height + bottom;
-                                }
-
-                                LayoutType::Row => {
-                                    current_posx += left + new_width + right;
-                                }
-
-                                _ => {}
-                            }
-
-                            (new_posx, new_posy)
-                        }
-                    };
-
-                    if new_posx != cache.posx(node) {
-                        cache.set_geo_changed(node, GeometryChanged::POSX_CHANGED, true);
-                    }
-
-                    if new_posy != cache.posy(node) {
-                        cache.set_geo_changed(node, GeometryChanged::POSY_CHANGED, true);
-                    }
-
-                    if new_width != cache.width(node) {
-                        cache.set_geo_changed(node, GeometryChanged::WIDTH_CHANGED, true);
-                    }
-
-                    if new_height != cache.height(node) {
-                        cache.set_geo_changed(node, GeometryChanged::HEIGHT_CHANGED, true);
-                    }
-
-                    cache.set_posx(node, new_posx);
-                    cache.set_posy(node, new_posy);
-                    cache.set_width(node, new_width);
-                    cache.set_height(node, new_height);
-                }
+                step3_row_col(parent, cache, hierarchy, store, Direction::X);
+                step3_row_col(parent, cache, hierarchy, store, Direction::Y);
             }
 
-            LayoutType::Grid => {
-                /////////////////////////////////////////////////////
-                // Determine Size of non-flexible rows and columns //
-                /////////////////////////////////////////////////////
-                let grid_rows = parent.grid_rows(store).unwrap_or_default();
-                let grid_cols = parent.grid_cols(store).unwrap_or_default();
-
-                let mut row_heights = vec![(0.0, 0.0); 2 * grid_rows.len() + 2];
-                let mut col_widths = vec![(0.0, 0.0,); 2 * grid_cols.len() + 2];
-
-                let row_heights_len = row_heights.len();
-                let col_widths_len = col_widths.len();
-
-                let mut col_free_space = parent_width;
-                let mut row_free_space = parent_height;
-
-                let mut row_stretch_sum = 0.0;
-                let mut col_stretch_sum = 0.0;
-
-                let row_between = parent.row_between(store).unwrap_or_default();
-                let col_between = parent.col_between(store).unwrap_or_default();
-
-                let child_left = parent.child_left(store).unwrap_or_default();
-                let child_right = parent.child_right(store).unwrap_or_default();
-                let child_top = parent.child_top(store).unwrap_or_default();
-                let child_bottom = parent.child_bottom(store).unwrap_or_default();
-
-                match child_top {
-                    Units::Pixels(val) => {
-                        row_heights[0].1 = val;
-                        row_free_space -= val;
-                    }
-
-                    Units::Stretch(val) => {
-                        row_stretch_sum += val;
-                    }
-
-                    _ => {}
-                }
-
-                match child_bottom {
-                    Units::Pixels(val) => {
-                        row_heights[row_heights_len - 1].1 = val;
-                        row_free_space -= val;
-                    }
-
-                    Units::Stretch(val) => {
-                        row_stretch_sum += val;
-                    }
-
-                    _ => {}
-                }
-
-                match child_left {
-                    Units::Pixels(val) => {
-                        col_widths[0].1 = val;
-                        col_free_space -= val;
-                    }
-
-                    Units::Stretch(val) => {
-                        col_stretch_sum += val;
-                    }
-
-                    _ => {}
-                }
-
-                match child_right {
-                    Units::Pixels(val) => {
-                        col_widths[col_widths_len - 1].1 = val;
-                        col_free_space -= val;
-                    }
-
-                    Units::Stretch(val) => {
-                        col_stretch_sum += val;
-                    }
-
-                    _ => {}
-                }
-
-                for (i, row) in grid_rows.iter().enumerate() {
-                    let row_index = 2 * i + 1;
-
-                    match row {
-                        &Units::Pixels(val) => {
-                            row_heights[row_index].1 = val;
-                            row_free_space -= val;
-                        }
-
-                        &Units::Stretch(val) => {
-                            row_stretch_sum += val;
-                        }
-
-                        _ => {}
-                    }
-
-                    if i < grid_rows.len() - 1 {
-                        let gutter_index = 2 * i + 2;
-                        match row_between {
-                            Units::Pixels(val) => {
-                                row_heights[gutter_index].1 = val;
-                                row_free_space -= val;
-                            }
-
-                            Units::Stretch(val) => {
-                                row_stretch_sum += val;
-                            }
-
-                            _ => {}
-                        }
-                    }
-                }
-
-                for (i, col) in grid_cols.iter().enumerate() {
-                    let col_index = 2 * i + 1;
-                    match col {
-                        &Units::Pixels(val) => {
-                            col_widths[col_index].1 = val;
-                            col_free_space -= val;
-                        }
-
-                        &Units::Stretch(val) => {
-                            col_stretch_sum += val;
-                        }
-
-                        _ => {}
-                    }
-
-                    if i < grid_cols.len() - 1 {
-                        let gutter_index = 2 * i + 2;
-                        match col_between {
-                            Units::Pixels(val) => {
-                                col_widths[gutter_index].1 = val;
-                                col_free_space -= val;
-                            }
-
-                            Units::Stretch(val) => {
-                                col_stretch_sum += val;
-                            }
-
-                            _ => {}
-                        }
-                    }
-                }
-
-                if row_stretch_sum == 0.0 {
-                    row_stretch_sum = 1.0;
-                }
-                if col_stretch_sum == 0.0 {
-                    col_stretch_sum = 1.0;
-                }
-
-                /////////////////////////////////////////////////
-                // Determine Size of flexible rows and columns //
-                /////////////////////////////////////////////////
-
-                match child_top {
-                    Units::Stretch(val) => {
-                        row_heights[0].1 = row_free_space * val / row_stretch_sum;
-                    }
-
-                    _ => {}
-                }
-
-                match child_bottom {
-                    Units::Stretch(val) => {
-                        row_heights[row_heights_len - 1].1 = row_free_space * val / row_stretch_sum;
-                    }
-
-                    _ => {}
-                }
-
-                match child_left {
-                    Units::Stretch(val) => {
-                        col_widths[0].1 = col_free_space * val / col_stretch_sum;
-                    }
-
-                    _ => {}
-                }
-
-                match child_right {
-                    Units::Stretch(val) => {
-                        col_widths[col_widths_len - 1].1 = col_free_space * val / col_stretch_sum;
-                    }
-
-                    _ => {}
-                }
-
-                let mut current_row_pos = cache.posy(parent) + row_heights[0].1;
-                let mut current_col_pos = cache.posx(parent) + col_widths[0].1;
-
-                for (i, row) in grid_rows.iter().enumerate() {
-                    let row_index = 2 * i + 1;
-                    match row {
-                        &Units::Stretch(val) => {
-                            row_heights[row_index].1 = row_free_space * val / row_stretch_sum;
-                        }
-
-                        _ => {}
-                    }
-
-                    row_heights[row_index].0 = current_row_pos;
-                    current_row_pos += row_heights[row_index].1;
-
-                    if i < grid_rows.len() - 1 {
-                        let gutter_index = 2 * i + 2;
-                        match row_between {
-                            Units::Stretch(val) => {
-                                row_heights[gutter_index].1 =
-                                    row_free_space * val / row_stretch_sum;
-                            }
-
-                            _ => {}
-                        }
-
-                        row_heights[gutter_index].0 = current_row_pos;
-                        current_row_pos += row_heights[gutter_index].1;
-                    }
-                }
-                let row_heights_len = row_heights.len() - 1;
-                row_heights[row_heights_len - 1].0 = current_row_pos;
-
-                for (i, col) in grid_cols.iter().enumerate() {
-                    let col_index = 2 * i + 1;
-
-                    match col {
-                        &Units::Stretch(val) => {
-                            col_widths[col_index].1 = col_free_space * val / col_stretch_sum;
-                        }
-
-                        _ => {}
-                    }
-
-                    col_widths[col_index].0 = current_col_pos;
-                    current_col_pos += col_widths[col_index].1;
-
-                    if i < grid_cols.len() - 1 {
-                        let gutter_index = 2 * i + 2;
-                        match col_between {
-                            Units::Stretch(val) => {
-                                col_widths[gutter_index].1 = col_free_space * val / col_stretch_sum;
-                            }
-
-                            _ => {}
-                        }
-
-                        col_widths[gutter_index].0 = current_col_pos;
-                        current_col_pos += col_widths[gutter_index].1;
-                    }
-                }
-
-                let col_widths_len = col_widths.len() - 1;
-                col_widths[col_widths_len - 1].0 = current_col_pos;
-
-                ///////////////////////////////////////////////////
-                // Position and Size child nodes within the grid //
-                ///////////////////////////////////////////////////
-                for node in hierarchy.child_iter(parent) {
-                    let visible = cache.visible(node);
-                    if !visible {
-                        continue;
-                    }
-
-                    let row_start = 2 * node.row_index(store).unwrap_or_default() + 1;
-                    let row_span = 2 * node.row_span(store).unwrap_or(1) - 1;
-                    let row_end = row_start + row_span;
-
-                    let col_start = 2 * node.col_index(store).unwrap_or_default() + 1;
-                    let col_span = 2 * node.col_span(store).unwrap_or(1) - 1;
-                    let col_end = col_start + col_span;
-
-                    let new_posx = col_widths[col_start].0;
-                    let new_width = col_widths[col_end].0 - new_posx;
-
-                    let new_posy = row_heights[row_start].0;
-                    let new_height = row_heights[row_end].0 - new_posy;
-
-                    if new_posx != cache.posx(node) {
-                        cache.set_geo_changed(node, GeometryChanged::POSX_CHANGED, true);
-                    }
-
-                    if new_posy != cache.posy(node) {
-                        cache.set_geo_changed(node, GeometryChanged::POSY_CHANGED, true);
-                    }
-
-                    if new_width != cache.width(node) {
-                        cache.set_geo_changed(node, GeometryChanged::WIDTH_CHANGED, true);
-                    }
-
-                    if new_height != cache.height(node) {
-                        cache.set_geo_changed(node, GeometryChanged::HEIGHT_CHANGED, true);
-                    }
-
-                    cache.set_posx(node, new_posx);
-                    cache.set_posy(node, new_posy);
-                    cache.set_width(node, new_width);
-                    cache.set_height(node, new_height);
-
-                    cache.set_new_width(node, cache.width(node));
-                    cache.set_new_height(node, cache.height(node));
-                }
-            }
+            LayoutType::Grid => step3_grid(parent, cache, hierarchy, store),
         }
     }
 }
@@ -1140,17 +169,7 @@ pub fn step2<'a, C, N>(
     // If Auto, then set the minimum height to be at least the height_sum/height_max/col_max of the children (depending on layout type)
     let mut min_width_height = node.min_width_height(store, dir).unwrap_or_default().value_or(
         parent_width_height,
-        match layout_type {
-            LayoutType::Column => match dir {
-                Direction::X => cache.child_width_max(node),
-                Direction::Y => cache.child_height_sum(node),
-            },
-            LayoutType::Row => match dir {
-                Direction::X => cache.child_width_sum(node),
-                Direction::Y => cache.child_height_max(node),
-            }
-            LayoutType::Grid => cache.grid_row_col_max(node, dir),
-        },
+        cache.child_width_height_layout(node, dir, layout_type),
     );
     min_width_height = min_width_height.clamp(0.0, f32::MAX);
 
@@ -1222,19 +241,7 @@ pub fn step2<'a, C, N>(
                 }
 
                 Units::Auto => {
-                    match layout_type {
-                        LayoutType::Column => {
-                            new_width_height = match dir { Direction::X => cache.child_width_max(node), Direction::Y => cache.child_height_sum(node), };
-                        }
-
-                        LayoutType::Row => {
-                            new_width_height = match dir { Direction::X => cache.child_width_sum(node), Direction::Y => cache.child_height_max(node), };
-                        }
-
-                        LayoutType::Grid => {
-                            new_width_height = cache.grid_row_col_max(node, dir);
-                        }
-                    }
+                    new_width_height = cache.child_width_height_layout(node, dir, layout_type);
 
                     new_width_height = new_width_height.clamp(min_width_height, max_width_height);
 
@@ -1288,6 +295,661 @@ pub fn step2<'a, C, N>(
 
         LayoutType::Grid => {
             // TODO
+        }
+    }
+}
+
+pub fn step3_row_col<'a, C, H>(
+    parent: <H as Hierarchy<'a>>::Item,
+    cache: &mut C,
+    hierarchy: &'a H,
+    store: &'a <<H as Hierarchy<'a>>::Item as Node<'a>>::Data,
+    dir: Direction,
+) where
+    C: Cache<Item = <H as Hierarchy<'a>>::Item>,
+    H: Hierarchy<'a>,
+{
+
+    let parent_layout_type = parent.layout_type(store).unwrap_or_default();
+    let child_left_top = parent.child_left_top(store, dir).unwrap_or_default();
+    let child_right_bottom = parent.child_right_bottom(store, dir).unwrap_or_default();
+
+    let row_col_between = parent.row_col_between(store, dir).unwrap_or_default();
+
+    let mut parent_width_height = cache.new_width_height(parent, dir);
+    let parent_width_hard = cache.new_width(parent);
+
+    let parent_border_left_top =
+        parent.border_left_top(store, dir).unwrap_or_default().value_or(parent_width_hard, 0.0);
+    let parent_border_right_bottom =
+        parent.border_right_bottom(store, dir).unwrap_or_default().value_or(parent_width_hard, 0.0);
+
+    parent_width_height -= parent_border_left_top + parent_border_right_bottom;
+
+    let mut parent_free_space = parent_width_height;
+    let mut parent_stretch_sum = 0.0;
+
+    let mut axis = SmallVec::<[ComputedData<<H as Hierarchy>::Item>; 3]>::new();
+
+    // ////////////////////////////////
+    // Calculate inflexible children //
+    ///////////////////////////////////
+    for node in hierarchy.child_iter(parent) {
+        let visible = cache.visible(node);
+        if !visible {
+            continue;
+        }
+
+        let layout_type = node.layout_type(store).unwrap_or_default();
+
+        let mut left_top = node.left_top(store, dir).unwrap_or_default();
+        let mut right_bottom = node.right_bottom(store, dir).unwrap_or_default();
+
+        let min_left_top = node
+            .min_left_top(store, dir)
+            .unwrap_or_default()
+            .value_or(parent_width_height, -f32::MAX);
+        let max_left_top = node
+            .max_left_top(store, dir)
+            .unwrap_or_default()
+            .value_or(parent_width_height, f32::MAX);
+        let min_right_bottom = node
+            .min_right_bottom(store, dir)
+            .unwrap_or_default()
+            .value_or(parent_width_height, -f32::MAX);
+        let max_right_bottom = node
+            .max_right_bottom(store, dir)
+            .unwrap_or_default()
+            .value_or(parent_width_height, f32::MAX);
+
+        let width_height = node.width_height(store, dir).unwrap_or(Units::Stretch(1.0));
+
+        // TODO - This could be cached during up phase because it shouldn't change between up phase and down phase
+        let mut min_width_height = node.min_width_height(store, dir).unwrap_or_default().value_or(
+            parent_width_height,
+            cache.child_width_height_layout(node, dir, layout_type),
+        );
+        min_width_height = min_width_height.clamp(0.0, f32::MAX);
+
+        let mut max_width_height = node
+            .max_width_height(store, dir)
+            .unwrap_or_default()
+            .value_or(parent_width_height, f32::MAX);
+        max_width_height = max_width_height.max(min_width_height);
+
+        let border_left_top =
+            node.border_left_top(store, dir).unwrap_or_default().value_or(parent_width_hard, 0.0);
+        let border_right_bottom =
+            node.border_right_bottom(store, dir).unwrap_or_default().value_or(parent_width_hard, 0.0);
+
+        let position_type = node.position_type(store).unwrap_or_default();
+
+        // Parent overrides
+        if let Some(layout_dir) = parent_layout_type.direction() {
+            if layout_dir == dir {
+                if left_top == Units::Auto {
+                    if cache.stack_first_child(node) {
+                        left_top = child_left_top;
+                    } else {
+                        left_top = row_col_between;
+                    }
+                }
+                if right_bottom == Units::Auto {
+                    if cache.stack_first_child(node) {
+                        right_bottom = child_right_bottom;
+                    }
+                }
+            } else {
+                if left_top == Units::Auto {
+                    left_top = child_left_top;
+                }
+                if right_bottom == Units::Auto {
+                    right_bottom = child_right_bottom;
+                }
+            }
+        }
+
+        let mut stretch_sum = 0.0;
+        let mut free_space = parent_width_height;
+
+        let new_left_top = incorperate_axis(
+            left_top,
+            parent_width_height,
+            min_left_top,
+            max_left_top,
+            &mut free_space,
+            &mut stretch_sum,
+            Axis::Before,
+            &mut axis,
+            node,
+            0.0
+        );
+        let new_width_bottom = incorperate_axis(
+            width_height,
+            parent_width_height,
+            min_width_height,
+            max_width_height,
+            &mut free_space,
+            &mut stretch_sum,
+            Axis::Size,
+            &mut axis,
+            node,
+            {
+                let mut auto = cache.child_width_height_layout(node, dir, layout_type);
+                auto = auto.clamp(min_width_height, max_width_height);
+                auto += border_left_top + border_right_bottom;
+                auto
+            }
+        );
+        let new_right_bottom = incorperate_axis(
+            right_bottom,
+            parent_width_height,
+            min_right_bottom,
+            max_right_bottom,
+            &mut free_space,
+            &mut stretch_sum,
+            Axis::After,
+            &mut axis,
+            node,
+            0.0
+        );
+
+        cache.set_new_width_height(node, new_width_bottom, dir);
+        cache.set_left_top(node, new_left_top, dir);
+        cache.set_right_bottom(node, new_right_bottom, dir);
+
+        if position_type == PositionType::ParentDirected {
+            parent_free_space -= parent_width_height - free_space;
+            parent_stretch_sum += stretch_sum;
+        }
+
+        // eh. these could be multiplexed but I don't really care
+        cache.set_h_v_free_space(node, free_space, dir);
+        cache.set_h_v_stretch_sum(node, stretch_sum, dir);
+    }
+
+    if parent_stretch_sum == 0.0 {
+        parent_stretch_sum = 1.0;
+    }
+
+    // Sort the stretch elements in each axis by the maximum size
+    axis.sort_by(|a, b| b.min.partial_cmp(&a.min).unwrap());
+
+    let mut stretch_sum = 0.0;
+    let mut free_space = 0.0;
+
+    /////////////////////////////////////
+    // Calculate flexible space & size //
+    /////////////////////////////////////
+    for computed_data in axis.iter() {
+        let node = computed_data.node.clone();
+
+        let position_type = node.position_type(store).unwrap_or_default();
+
+        match position_type {
+            PositionType::SelfDirected => {
+                free_space = cache.h_v_free_space(node, dir);
+                stretch_sum = cache.h_v_stretch_sum(node, dir);
+            }
+
+            PositionType::ParentDirected => {
+                if let Some(parent_layout_dir) = parent_layout_type.direction() {
+                    if parent_layout_dir == dir {
+                        stretch_sum = parent_stretch_sum;
+                        free_space = parent_free_space;
+                    } else {
+                        free_space = cache.h_v_free_space(node, dir);
+                        stretch_sum = cache.h_v_stretch_sum(node, dir);
+                    }
+                }
+            }
+        }
+
+        // Prevent a divide by zero when the stretch sum is 0
+        if stretch_sum == 0.0 {
+            stretch_sum = 1.0;
+        }
+
+        // Compute the new left/width/height based on free space, stretch factor, and stretch_sum
+        #[cfg(feature = "rounding")]
+        let mut new_value = (free_space * computed_data.value / stretch_sum).round();
+        #[cfg(not(feature = "rounding"))]
+        let mut new_value = free_space * computed_data.value / stretch_sum;
+
+        // Clamp the new left/width/right to be between min_ left/width/right and max_ left/width/right
+        new_value = new_value.clamp(computed_data.min, computed_data.max);
+
+        // Could perhaps replace this with a closure
+        match computed_data.axis {
+            Axis::Before => cache.set_left_top(node, new_value, dir),
+            Axis::Size => cache.set_new_width_height(node, new_value, dir),
+            Axis::After => cache.set_right_bottom(node, new_value, dir),
+        }
+
+        match position_type {
+            PositionType::SelfDirected => {
+                cache.set_h_v_stretch_sum(node, stretch_sum - computed_data.value, dir);
+                cache.set_h_v_free_space(node, free_space - new_value, dir);
+            }
+
+            PositionType::ParentDirected => {
+                if let Some(parent_layout_dir) = parent_layout_type.direction() {
+                    if parent_layout_dir == dir {
+                        parent_free_space -= new_value;
+                        parent_stretch_sum -= computed_data.value;
+                    } else {
+                        cache.set_h_v_stretch_sum(
+                            node,
+                            stretch_sum - computed_data.value,
+                            dir,
+                        );
+                        cache.set_h_v_free_space(node, free_space - new_value, dir);
+                    }
+                }
+            }
+        }
+    }
+
+    let mut current_posx_posy = 0.0;
+    let parent_posx_posy = cache.posx_posy(parent, dir) + parent_border_left_top;
+
+    ///////////////////////
+    // Position Children //
+    ///////////////////////
+    for node in hierarchy.child_iter(parent) {
+        let visible = cache.visible(node);
+        if !visible {
+            continue;
+        }
+
+        let left_top = cache.left_top(node, dir);
+        let right_bottom = cache.right_bottom(node, dir);
+
+        let new_width_height = cache.new_width_height(node, dir);
+
+        let position_type = node.position_type(store).unwrap_or_default();
+
+        let new_posx_posy = match position_type {
+            PositionType::SelfDirected => parent_posx_posy + left_top,
+
+            PositionType::ParentDirected => {
+                let new_posx_posy = parent_posx_posy + current_posx_posy + left_top;
+
+                if let Some(parent_layout_dir) = parent_layout_type.direction() {
+                    if parent_layout_dir == dir {
+                        current_posx_posy += left_top + new_width_height + right_bottom;
+                    }
+                }
+
+                new_posx_posy
+            }
+        };
+
+        if new_posx_posy != cache.posx_posy(node, dir) {
+            cache.set_geo_changed(node, GeometryChanged::pos_changed(dir), true);
+        }
+
+        if new_width_height != cache.width_height(node, dir) {
+            cache.set_geo_changed(node, GeometryChanged::size_changed(dir), true);
+        }
+
+        cache.set_posx_posy(node, new_posx_posy, dir);
+        cache.set_width_height(node, new_width_height, dir);
+    }
+}
+
+pub fn step3_grid<'a, C, H>(
+    parent: <H as Hierarchy<'a>>::Item,
+    cache: &mut C,
+    hierarchy: &'a H,
+    store: &'a <<H as Hierarchy<'a>>::Item as Node<'a>>::Data,
+) where
+    C: Cache<Item = <H as Hierarchy<'a>>::Item>,
+    H: Hierarchy<'a>,
+{
+    let parent_width = cache.new_width(parent);
+    let parent_height = cache.new_height(parent);
+
+    /////////////////////////////////////////////////////
+    // Determine Size of non-flexible rows and columns //
+    /////////////////////////////////////////////////////
+    let grid_rows = parent.grid_rows(store).unwrap_or_default();
+    let grid_cols = parent.grid_cols(store).unwrap_or_default();
+
+    let mut row_heights = vec![(0.0, 0.0); 2 * grid_rows.len() + 2];
+    let mut col_widths = vec![(0.0, 0.0,); 2 * grid_cols.len() + 2];
+
+    let row_heights_len = row_heights.len();
+    let col_widths_len = col_widths.len();
+
+    let mut col_free_space = parent_width;
+    let mut row_free_space = parent_height;
+
+    let mut row_stretch_sum = 0.0;
+    let mut col_stretch_sum = 0.0;
+
+    let row_between = parent.row_between(store).unwrap_or_default();
+    let col_between = parent.col_between(store).unwrap_or_default();
+
+    let child_left = parent.child_left(store).unwrap_or_default();
+    let child_right = parent.child_right(store).unwrap_or_default();
+    let child_top = parent.child_top(store).unwrap_or_default();
+    let child_bottom = parent.child_bottom(store).unwrap_or_default();
+
+    match child_top {
+        Units::Pixels(val) => {
+            row_heights[0].1 = val;
+            row_free_space -= val;
+        }
+
+        Units::Stretch(val) => {
+            row_stretch_sum += val;
+        }
+
+        _ => {}
+    }
+
+    match child_bottom {
+        Units::Pixels(val) => {
+            row_heights[row_heights_len - 1].1 = val;
+            row_free_space -= val;
+        }
+
+        Units::Stretch(val) => {
+            row_stretch_sum += val;
+        }
+
+        _ => {}
+    }
+
+    match child_left {
+        Units::Pixels(val) => {
+            col_widths[0].1 = val;
+            col_free_space -= val;
+        }
+
+        Units::Stretch(val) => {
+            col_stretch_sum += val;
+        }
+
+        _ => {}
+    }
+
+    match child_right {
+        Units::Pixels(val) => {
+            col_widths[col_widths_len - 1].1 = val;
+            col_free_space -= val;
+        }
+
+        Units::Stretch(val) => {
+            col_stretch_sum += val;
+        }
+
+        _ => {}
+    }
+
+    for (i, row) in grid_rows.iter().enumerate() {
+        let row_index = 2 * i + 1;
+
+        match row {
+            &Units::Pixels(val) => {
+                row_heights[row_index].1 = val;
+                row_free_space -= val;
+            }
+
+            &Units::Stretch(val) => {
+                row_stretch_sum += val;
+            }
+
+            _ => {}
+        }
+
+        if i < grid_rows.len() - 1 {
+            let gutter_index = 2 * i + 2;
+            match row_between {
+                Units::Pixels(val) => {
+                    row_heights[gutter_index].1 = val;
+                    row_free_space -= val;
+                }
+
+                Units::Stretch(val) => {
+                    row_stretch_sum += val;
+                }
+
+                _ => {}
+            }
+        }
+    }
+
+    for (i, col) in grid_cols.iter().enumerate() {
+        let col_index = 2 * i + 1;
+        match col {
+            &Units::Pixels(val) => {
+                col_widths[col_index].1 = val;
+                col_free_space -= val;
+            }
+
+            &Units::Stretch(val) => {
+                col_stretch_sum += val;
+            }
+
+            _ => {}
+        }
+
+        if i < grid_cols.len() - 1 {
+            let gutter_index = 2 * i + 2;
+            match col_between {
+                Units::Pixels(val) => {
+                    col_widths[gutter_index].1 = val;
+                    col_free_space -= val;
+                }
+
+                Units::Stretch(val) => {
+                    col_stretch_sum += val;
+                }
+
+                _ => {}
+            }
+        }
+    }
+
+    if row_stretch_sum == 0.0 {
+        row_stretch_sum = 1.0;
+    }
+    if col_stretch_sum == 0.0 {
+        col_stretch_sum = 1.0;
+    }
+
+    /////////////////////////////////////////////////
+    // Determine Size of flexible rows and columns //
+    /////////////////////////////////////////////////
+
+    match child_top {
+        Units::Stretch(val) => {
+            row_heights[0].1 = row_free_space * val / row_stretch_sum;
+        }
+
+        _ => {}
+    }
+
+    match child_bottom {
+        Units::Stretch(val) => {
+            row_heights[row_heights_len - 1].1 = row_free_space * val / row_stretch_sum;
+        }
+
+        _ => {}
+    }
+
+    match child_left {
+        Units::Stretch(val) => {
+            col_widths[0].1 = col_free_space * val / col_stretch_sum;
+        }
+
+        _ => {}
+    }
+
+    match child_right {
+        Units::Stretch(val) => {
+            col_widths[col_widths_len - 1].1 = col_free_space * val / col_stretch_sum;
+        }
+
+        _ => {}
+    }
+
+    let mut current_row_pos = cache.posy(parent) + row_heights[0].1;
+    let mut current_col_pos = cache.posx(parent) + col_widths[0].1;
+
+    for (i, row) in grid_rows.iter().enumerate() {
+        let row_index = 2 * i + 1;
+        match row {
+            &Units::Stretch(val) => {
+                row_heights[row_index].1 = row_free_space * val / row_stretch_sum;
+            }
+
+            _ => {}
+        }
+
+        row_heights[row_index].0 = current_row_pos;
+        current_row_pos += row_heights[row_index].1;
+
+        if i < grid_rows.len() - 1 {
+            let gutter_index = 2 * i + 2;
+            match row_between {
+                Units::Stretch(val) => {
+                    row_heights[gutter_index].1 =
+                        row_free_space * val / row_stretch_sum;
+                }
+
+                _ => {}
+            }
+
+            row_heights[gutter_index].0 = current_row_pos;
+            current_row_pos += row_heights[gutter_index].1;
+        }
+    }
+    let row_heights_len = row_heights.len() - 1;
+    row_heights[row_heights_len - 1].0 = current_row_pos;
+
+    for (i, col) in grid_cols.iter().enumerate() {
+        let col_index = 2 * i + 1;
+
+        match col {
+            &Units::Stretch(val) => {
+                col_widths[col_index].1 = col_free_space * val / col_stretch_sum;
+            }
+
+            _ => {}
+        }
+
+        col_widths[col_index].0 = current_col_pos;
+        current_col_pos += col_widths[col_index].1;
+
+        if i < grid_cols.len() - 1 {
+            let gutter_index = 2 * i + 2;
+            match col_between {
+                Units::Stretch(val) => {
+                    col_widths[gutter_index].1 = col_free_space * val / col_stretch_sum;
+                }
+
+                _ => {}
+            }
+
+            col_widths[gutter_index].0 = current_col_pos;
+            current_col_pos += col_widths[gutter_index].1;
+        }
+    }
+
+    let col_widths_len = col_widths.len() - 1;
+    col_widths[col_widths_len - 1].0 = current_col_pos;
+
+    ///////////////////////////////////////////////////
+    // Position and Size child nodes within the grid //
+    ///////////////////////////////////////////////////
+    for node in hierarchy.child_iter(parent) {
+        let visible = cache.visible(node);
+        if !visible {
+            continue;
+        }
+
+        let row_start = 2 * node.row_index(store).unwrap_or_default() + 1;
+        let row_span = 2 * node.row_span(store).unwrap_or(1) - 1;
+        let row_end = row_start + row_span;
+
+        let col_start = 2 * node.col_index(store).unwrap_or_default() + 1;
+        let col_span = 2 * node.col_span(store).unwrap_or(1) - 1;
+        let col_end = col_start + col_span;
+
+        let new_posx = col_widths[col_start].0;
+        let new_width = col_widths[col_end].0 - new_posx;
+
+        let new_posy = row_heights[row_start].0;
+        let new_height = row_heights[row_end].0 - new_posy;
+
+        if new_posx != cache.posx(node) {
+            cache.set_geo_changed(node, GeometryChanged::POSX_CHANGED, true);
+        }
+
+        if new_posy != cache.posy(node) {
+            cache.set_geo_changed(node, GeometryChanged::POSY_CHANGED, true);
+        }
+
+        if new_width != cache.width(node) {
+            cache.set_geo_changed(node, GeometryChanged::WIDTH_CHANGED, true);
+        }
+
+        if new_height != cache.height(node) {
+            cache.set_geo_changed(node, GeometryChanged::HEIGHT_CHANGED, true);
+        }
+
+        cache.set_posx(node, new_posx);
+        cache.set_posy(node, new_posy);
+        cache.set_width(node, new_width);
+        cache.set_height(node, new_height);
+
+        cache.set_new_width(node, cache.width(node));
+        cache.set_new_height(node, cache.height(node));
+    }
+}
+
+fn incorperate_axis<N: Clone + for<'w> Node<'w>>(
+    units: Units,
+    parent_size: f32,
+    min: f32,
+    max: f32,
+    free_space: &mut f32,
+    stretch_sum: &mut f32,
+    axis: Axis,
+    axis_buf: &mut SmallVec<[ComputedData<N>; 3]>,
+    node: N,
+    auto_size: f32,
+) -> f32 {
+    match units {
+        Units::Pixels(val) => {
+            let new = val.clamp(min, max);
+            *free_space -= new;
+            new
+        }
+
+        Units::Percentage(val) => {
+            let new = (val / 100.0) * parent_size;
+            let new = new.clamp(min, max);
+            *free_space -= new;
+            new
+        }
+
+        Units::Stretch(val) => {
+            *stretch_sum += val;
+            axis_buf.push(ComputedData {
+                node: node.clone(),
+                value: val,
+                min, max, axis,
+            });
+            0.0
+        }
+
+        Units::Auto => {
+            *free_space -= auto_size;
+            auto_size
         }
     }
 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -190,4 +190,114 @@ pub trait Node<'w>: Clone + Copy + std::fmt::Debug {
     fn border_bottom(&self, store: &'_ Self::Data) -> Option<Units> {
         Some(Units::Auto)
     }
+
+    // these are "generic getters"
+    fn width_height(&self, store: &'_ Self::Data, axis: Axis) -> Option<Units> {
+        match axis {
+            Axis::X => self.width(store),
+            Axis::Y => self.height(store),
+        }
+    }
+    fn min_width_height(&self, store: &'_ Self::Data, axis: Axis) -> Option<Units> {
+        match axis {
+            Axis::X => self.min_width(store),
+            Axis::Y => self.min_height(store),
+        }
+    }
+    fn max_width_height(&self, store: &'_ Self::Data, axis: Axis) -> Option<Units> {
+        match axis {
+            Axis::X => self.max_width(store),
+            Axis::Y => self.max_height(store),
+        }
+    }
+    fn content_width_height(&self, store: &'_ Self::Data, axis: Axis) -> Option<f32> {
+        match axis {
+            Axis::X => self.content_width(store),
+            Axis::Y => self.content_height(store),
+        }
+    }
+    fn left_top(&self, store: &'_ Self::Data, axis: Axis) -> Option<Units> {
+        match axis {
+            Axis::X => self.left(store),
+            Axis::Y => self.top(store),
+        }
+    }
+    fn right_bottom(&self, store: &'_ Self::Data, axis: Axis) -> Option<Units> {
+        match axis {
+            Axis::X => self.right(store),
+            Axis::Y => self.bottom(store),
+        }
+    }
+    fn min_left_top(&self, store: &'_ Self::Data, axis: Axis) -> Option<Units> {
+        match axis {
+            Axis::X => self.min_left(store),
+            Axis::Y => self.min_top(store),
+        }
+    }
+    fn max_left_top(&self, store: &'_ Self::Data, axis: Axis) -> Option<Units> {
+        match axis {
+            Axis::X => self.max_left(store),
+            Axis::Y => self.max_top(store),
+        }
+    }
+    fn min_right_bottom(&self, store: &'_ Self::Data, axis: Axis) -> Option<Units> {
+        match axis {
+            Axis::X => self.min_right(store),
+            Axis::Y => self.min_bottom(store),
+        }
+    }
+    fn max_right_bottom(&self, store: &'_ Self::Data, axis: Axis) -> Option<Units> {
+        match axis {
+            Axis::X => self.max_right(store),
+            Axis::Y => self.max_bottom(store),
+        }
+    }
+    fn child_left_top(&self, store: &'_ Self::Data, axis: Axis) -> Option<Units> {
+        match axis {
+            Axis::X => self.child_left(store),
+            Axis::Y => self.child_top(store),
+        }
+    }
+    fn child_right_bottom(&self, store: &'_ Self::Data, axis: Axis) -> Option<Units> {
+        match axis {
+            Axis::X => self.child_right(store),
+            Axis::Y => self.child_bottom(store),
+        }
+    }
+    fn row_col_between(&self, store: &'_ Self::Data, axis: Axis) -> Option<Units> {
+        match axis {
+            Axis::X => self.row_between(store),
+            Axis::Y => self.col_between(store),
+        }
+    }
+    fn grid_rows_cols(&self, store: &'_ Self::Data, axis: Axis) -> Option<Vec<Units>> {
+        match axis {
+            Axis::X => self.grid_rows(store),
+            Axis::Y => self.grid_cols(store),
+        }
+    }
+    fn row_col_index(&self, store: &'_ Self::Data, axis: Axis) -> Option<usize> {
+        match axis {
+            Axis::X => self.row_index(store),
+            Axis::Y => self.col_index(store),
+        }
+    }
+    fn row_col_span(&self, store: &'_ Self::Data, axis: Axis) -> Option<usize> {
+        match axis {
+            Axis::X => self.row_span(store),
+            Axis::Y => self.col_span(store),
+        }
+    }
+    fn border_left_top(&self, store: &'_ Self::Data, axis: Axis) -> Option<Units> {
+        match axis {
+            Axis::X => self.border_left(store),
+            Axis::Y => self.border_top(store),
+        }
+    }
+    fn border_right_bottom(&self, store: &'_ Self::Data, axis: Axis) -> Option<Units> {
+        match axis {
+            Axis::X => self.border_right(store),
+            Axis::Y => self.border_bottom(store),
+        }
+    }
 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -192,73 +192,73 @@ pub trait Node<'w>: Clone + Copy + std::fmt::Debug {
     }
 
     // these are "generic getters"
-    fn width_height(&self, store: &'_ Self::Data, axis: Direction) -> Option<Units> {
+    fn size(&self, store: &'_ Self::Data, axis: Direction) -> Option<Units> {
         match axis {
             Direction::X => self.width(store),
             Direction::Y => self.height(store),
         }
     }
-    fn min_width_height(&self, store: &'_ Self::Data, axis: Direction) -> Option<Units> {
+    fn min_size(&self, store: &'_ Self::Data, axis: Direction) -> Option<Units> {
         match axis {
             Direction::X => self.min_width(store),
             Direction::Y => self.min_height(store),
         }
     }
-    fn max_width_height(&self, store: &'_ Self::Data, axis: Direction) -> Option<Units> {
+    fn max_size(&self, store: &'_ Self::Data, axis: Direction) -> Option<Units> {
         match axis {
             Direction::X => self.max_width(store),
             Direction::Y => self.max_height(store),
         }
     }
-    fn content_width_height(&self, store: &'_ Self::Data, axis: Direction) -> Option<f32> {
+    fn content_size(&self, store: &'_ Self::Data, axis: Direction) -> Option<f32> {
         match axis {
             Direction::X => self.content_width(store),
             Direction::Y => self.content_height(store),
         }
     }
-    fn left_top(&self, store: &'_ Self::Data, axis: Direction) -> Option<Units> {
+    fn before(&self, store: &'_ Self::Data, axis: Direction) -> Option<Units> {
         match axis {
             Direction::X => self.left(store),
             Direction::Y => self.top(store),
         }
     }
-    fn right_bottom(&self, store: &'_ Self::Data, axis: Direction) -> Option<Units> {
+    fn after(&self, store: &'_ Self::Data, axis: Direction) -> Option<Units> {
         match axis {
             Direction::X => self.right(store),
             Direction::Y => self.bottom(store),
         }
     }
-    fn min_left_top(&self, store: &'_ Self::Data, axis: Direction) -> Option<Units> {
+    fn min_before(&self, store: &'_ Self::Data, axis: Direction) -> Option<Units> {
         match axis {
             Direction::X => self.min_left(store),
             Direction::Y => self.min_top(store),
         }
     }
-    fn max_left_top(&self, store: &'_ Self::Data, axis: Direction) -> Option<Units> {
+    fn max_before(&self, store: &'_ Self::Data, axis: Direction) -> Option<Units> {
         match axis {
             Direction::X => self.max_left(store),
             Direction::Y => self.max_top(store),
         }
     }
-    fn min_right_bottom(&self, store: &'_ Self::Data, axis: Direction) -> Option<Units> {
+    fn min_after(&self, store: &'_ Self::Data, axis: Direction) -> Option<Units> {
         match axis {
             Direction::X => self.min_right(store),
             Direction::Y => self.min_bottom(store),
         }
     }
-    fn max_right_bottom(&self, store: &'_ Self::Data, axis: Direction) -> Option<Units> {
+    fn max_after(&self, store: &'_ Self::Data, axis: Direction) -> Option<Units> {
         match axis {
             Direction::X => self.max_right(store),
             Direction::Y => self.max_bottom(store),
         }
     }
-    fn child_left_top(&self, store: &'_ Self::Data, axis: Direction) -> Option<Units> {
+    fn child_before(&self, store: &'_ Self::Data, axis: Direction) -> Option<Units> {
         match axis {
             Direction::X => self.child_left(store),
             Direction::Y => self.child_top(store),
         }
     }
-    fn child_right_bottom(&self, store: &'_ Self::Data, axis: Direction) -> Option<Units> {
+    fn child_after(&self, store: &'_ Self::Data, axis: Direction) -> Option<Units> {
         match axis {
             Direction::X => self.child_right(store),
             Direction::Y => self.child_bottom(store),
@@ -288,13 +288,13 @@ pub trait Node<'w>: Clone + Copy + std::fmt::Debug {
             Direction::Y => self.col_span(store),
         }
     }
-    fn border_left_top(&self, store: &'_ Self::Data, axis: Direction) -> Option<Units> {
+    fn border_before(&self, store: &'_ Self::Data, axis: Direction) -> Option<Units> {
         match axis {
             Direction::X => self.border_left(store),
             Direction::Y => self.border_top(store),
         }
     }
-    fn border_right_bottom(&self, store: &'_ Self::Data, axis: Direction) -> Option<Units> {
+    fn border_after(&self, store: &'_ Self::Data, axis: Direction) -> Option<Units> {
         match axis {
             Direction::X => self.border_right(store),
             Direction::Y => self.border_bottom(store),

--- a/src/node.rs
+++ b/src/node.rs
@@ -192,112 +192,112 @@ pub trait Node<'w>: Clone + Copy + std::fmt::Debug {
     }
 
     // these are "generic getters"
-    fn width_height(&self, store: &'_ Self::Data, axis: Axis) -> Option<Units> {
+    fn width_height(&self, store: &'_ Self::Data, axis: Direction) -> Option<Units> {
         match axis {
-            Axis::X => self.width(store),
-            Axis::Y => self.height(store),
+            Direction::X => self.width(store),
+            Direction::Y => self.height(store),
         }
     }
-    fn min_width_height(&self, store: &'_ Self::Data, axis: Axis) -> Option<Units> {
+    fn min_width_height(&self, store: &'_ Self::Data, axis: Direction) -> Option<Units> {
         match axis {
-            Axis::X => self.min_width(store),
-            Axis::Y => self.min_height(store),
+            Direction::X => self.min_width(store),
+            Direction::Y => self.min_height(store),
         }
     }
-    fn max_width_height(&self, store: &'_ Self::Data, axis: Axis) -> Option<Units> {
+    fn max_width_height(&self, store: &'_ Self::Data, axis: Direction) -> Option<Units> {
         match axis {
-            Axis::X => self.max_width(store),
-            Axis::Y => self.max_height(store),
+            Direction::X => self.max_width(store),
+            Direction::Y => self.max_height(store),
         }
     }
-    fn content_width_height(&self, store: &'_ Self::Data, axis: Axis) -> Option<f32> {
+    fn content_width_height(&self, store: &'_ Self::Data, axis: Direction) -> Option<f32> {
         match axis {
-            Axis::X => self.content_width(store),
-            Axis::Y => self.content_height(store),
+            Direction::X => self.content_width(store),
+            Direction::Y => self.content_height(store),
         }
     }
-    fn left_top(&self, store: &'_ Self::Data, axis: Axis) -> Option<Units> {
+    fn left_top(&self, store: &'_ Self::Data, axis: Direction) -> Option<Units> {
         match axis {
-            Axis::X => self.left(store),
-            Axis::Y => self.top(store),
+            Direction::X => self.left(store),
+            Direction::Y => self.top(store),
         }
     }
-    fn right_bottom(&self, store: &'_ Self::Data, axis: Axis) -> Option<Units> {
+    fn right_bottom(&self, store: &'_ Self::Data, axis: Direction) -> Option<Units> {
         match axis {
-            Axis::X => self.right(store),
-            Axis::Y => self.bottom(store),
+            Direction::X => self.right(store),
+            Direction::Y => self.bottom(store),
         }
     }
-    fn min_left_top(&self, store: &'_ Self::Data, axis: Axis) -> Option<Units> {
+    fn min_left_top(&self, store: &'_ Self::Data, axis: Direction) -> Option<Units> {
         match axis {
-            Axis::X => self.min_left(store),
-            Axis::Y => self.min_top(store),
+            Direction::X => self.min_left(store),
+            Direction::Y => self.min_top(store),
         }
     }
-    fn max_left_top(&self, store: &'_ Self::Data, axis: Axis) -> Option<Units> {
+    fn max_left_top(&self, store: &'_ Self::Data, axis: Direction) -> Option<Units> {
         match axis {
-            Axis::X => self.max_left(store),
-            Axis::Y => self.max_top(store),
+            Direction::X => self.max_left(store),
+            Direction::Y => self.max_top(store),
         }
     }
-    fn min_right_bottom(&self, store: &'_ Self::Data, axis: Axis) -> Option<Units> {
+    fn min_right_bottom(&self, store: &'_ Self::Data, axis: Direction) -> Option<Units> {
         match axis {
-            Axis::X => self.min_right(store),
-            Axis::Y => self.min_bottom(store),
+            Direction::X => self.min_right(store),
+            Direction::Y => self.min_bottom(store),
         }
     }
-    fn max_right_bottom(&self, store: &'_ Self::Data, axis: Axis) -> Option<Units> {
+    fn max_right_bottom(&self, store: &'_ Self::Data, axis: Direction) -> Option<Units> {
         match axis {
-            Axis::X => self.max_right(store),
-            Axis::Y => self.max_bottom(store),
+            Direction::X => self.max_right(store),
+            Direction::Y => self.max_bottom(store),
         }
     }
-    fn child_left_top(&self, store: &'_ Self::Data, axis: Axis) -> Option<Units> {
+    fn child_left_top(&self, store: &'_ Self::Data, axis: Direction) -> Option<Units> {
         match axis {
-            Axis::X => self.child_left(store),
-            Axis::Y => self.child_top(store),
+            Direction::X => self.child_left(store),
+            Direction::Y => self.child_top(store),
         }
     }
-    fn child_right_bottom(&self, store: &'_ Self::Data, axis: Axis) -> Option<Units> {
+    fn child_right_bottom(&self, store: &'_ Self::Data, axis: Direction) -> Option<Units> {
         match axis {
-            Axis::X => self.child_right(store),
-            Axis::Y => self.child_bottom(store),
+            Direction::X => self.child_right(store),
+            Direction::Y => self.child_bottom(store),
         }
     }
-    fn row_col_between(&self, store: &'_ Self::Data, axis: Axis) -> Option<Units> {
+    fn row_col_between(&self, store: &'_ Self::Data, axis: Direction) -> Option<Units> {
         match axis {
-            Axis::X => self.row_between(store),
-            Axis::Y => self.col_between(store),
+            Direction::X => self.row_between(store),
+            Direction::Y => self.col_between(store),
         }
     }
-    fn grid_rows_cols(&self, store: &'_ Self::Data, axis: Axis) -> Option<Vec<Units>> {
+    fn grid_rows_cols(&self, store: &'_ Self::Data, axis: Direction) -> Option<Vec<Units>> {
         match axis {
-            Axis::X => self.grid_rows(store),
-            Axis::Y => self.grid_cols(store),
+            Direction::X => self.grid_rows(store),
+            Direction::Y => self.grid_cols(store),
         }
     }
-    fn row_col_index(&self, store: &'_ Self::Data, axis: Axis) -> Option<usize> {
+    fn row_col_index(&self, store: &'_ Self::Data, axis: Direction) -> Option<usize> {
         match axis {
-            Axis::X => self.row_index(store),
-            Axis::Y => self.col_index(store),
+            Direction::X => self.row_index(store),
+            Direction::Y => self.col_index(store),
         }
     }
-    fn row_col_span(&self, store: &'_ Self::Data, axis: Axis) -> Option<usize> {
+    fn row_col_span(&self, store: &'_ Self::Data, axis: Direction) -> Option<usize> {
         match axis {
-            Axis::X => self.row_span(store),
-            Axis::Y => self.col_span(store),
+            Direction::X => self.row_span(store),
+            Direction::Y => self.col_span(store),
         }
     }
-    fn border_left_top(&self, store: &'_ Self::Data, axis: Axis) -> Option<Units> {
+    fn border_left_top(&self, store: &'_ Self::Data, axis: Direction) -> Option<Units> {
         match axis {
-            Axis::X => self.border_left(store),
-            Axis::Y => self.border_top(store),
+            Direction::X => self.border_left(store),
+            Direction::Y => self.border_top(store),
         }
     }
-    fn border_right_bottom(&self, store: &'_ Self::Data, axis: Axis) -> Option<Units> {
+    fn border_right_bottom(&self, store: &'_ Self::Data, axis: Direction) -> Option<Units> {
         match axis {
-            Axis::X => self.border_right(store),
-            Axis::Y => self.border_bottom(store),
+            Direction::X => self.border_right(store),
+            Direction::Y => self.border_bottom(store),
         }
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,18 +1,18 @@
 use bitflags::bitflags;
 
 #[derive(Debug, Copy, Clone, PartialEq)]
-pub enum Axis {
+pub enum Direction {
     X,
     Y,
 }
 
-impl std::ops::Not for Axis {
+impl std::ops::Not for Direction {
     type Output = Self;
 
     fn not(self) -> Self::Output {
         match self {
-            Axis::X => Axis::Y,
-            Axis::Y => Axis::X,
+            Direction::X => Direction::Y,
+            Direction::Y => Direction::X,
         }
     }
 }
@@ -29,10 +29,10 @@ pub enum LayoutType {
 }
 
 impl LayoutType {
-    pub fn axis(&self) -> Option<Axis> {
+    pub fn axis(&self) -> Option<Direction> {
         match self {
-            LayoutType::Row => Some(Axis::X),
-            LayoutType::Column => Some(Axis::Y),
+            LayoutType::Row => Some(Direction::X),
+            LayoutType::Column => Some(Direction::Y),
             LayoutType::Grid => None,
         }
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -29,7 +29,7 @@ pub enum LayoutType {
 }
 
 impl LayoutType {
-    pub fn axis(&self) -> Option<Direction> {
+    pub fn direction(&self) -> Option<Direction> {
         match self {
             LayoutType::Row => Some(Direction::X),
             LayoutType::Column => Some(Direction::Y),
@@ -142,6 +142,36 @@ bitflags! {
         const WIDTH_CHANGED  = 0b01000000;
         /// The height of the node has changed
         const HEIGHT_CHANGED = 0b10000000;
+    }
+}
+
+impl GeometryChanged {
+    pub fn change_pos(dir: Direction) -> Self {
+        match dir {
+            Direction::X => Self::CHANGE_POSX,
+            Direction::Y => Self::CHANGE_POSY,
+        }
+    }
+
+    pub fn change_size(dir: Direction) -> Self {
+        match dir {
+            Direction::X => Self::CHANGE_WIDTH,
+            Direction::Y => Self::CHANGE_HEIGHT,
+        }
+    }
+
+    pub fn pos_changed(dir: Direction) -> Self {
+        match dir {
+            Direction::X => Self::POSX_CHANGED,
+            Direction::Y => Self::POSY_CHANGED,
+        }
+    }
+
+    pub fn size_changed(dir: Direction) -> Self {
+        match dir {
+            Direction::X => Self::WIDTH_CHANGED,
+            Direction::Y => Self::HEIGHT_CHANGED,
+        }
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,5 +1,22 @@
 use bitflags::bitflags;
 
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub enum Axis {
+    X,
+    Y,
+}
+
+impl std::ops::Not for Axis {
+    type Output = Self;
+
+    fn not(self) -> Self::Output {
+        match self {
+            Axis::X => Axis::Y,
+            Axis::Y => Axis::X,
+        }
+    }
+}
+
 /// The layout type determines how nodes will be positioned when directed by the parent
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum LayoutType {
@@ -9,6 +26,16 @@ pub enum LayoutType {
     Column,
     /// Position child elements into specified rows and columns
     Grid,
+}
+
+impl LayoutType {
+    pub fn axis(&self) -> Option<Axis> {
+        match self {
+            LayoutType::Row => Some(Axis::X),
+            LayoutType::Column => Some(Axis::Y),
+            LayoutType::Grid => None,
+        }
+    }
 }
 
 impl Default for LayoutType {


### PR DESCRIPTION
This is a prerequisite for the upcoming multiline text refactor, since we need to be able to run the horizontal and vertical layout in arbitrary orders.