### PR TITLE
Fix for self-directed nodes not being positioned correctly

### DIFF
--- a/src/layout.rs
+++ b/src/layout.rs
@@ -772,7 +772,6 @@ where
     for (index, child) in children
         .iter_mut()
         .filter(|child| child.node.position_type(store).unwrap_or_default() == PositionType::SelfDirected)
-        .filter(|child| !child.node.cross(store, layout_type).is_auto())
         .enumerate()
     {
         let mut child_cross_before = child.node.cross_before(store, layout_type);


### PR DESCRIPTION
This fixes a bug where auto-sized self-directed nodes with stretch cross space weren't being positioned correctly. This was due to a filter on the child iterator causing the computation to skip stretch cross space if the node had an auto cross size.