### PR TITLE
Add `auto` min-size

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -131,13 +131,17 @@ fn main() {
     // world.set_layout_type(root, LayoutType::Row);
 
     let node = world.add(Some(root));
-    world.set_width(node, Units::Auto);
+    world.set_width(node, Units::Stretch(1.0));
     world.set_height(node, Units::Stretch(1.0));
-    // world.set_child_space(node, Units::Pixels(20.0));
+    world.set_min_width(node, Units::Auto);
+    world.set_min_height(node, Units::Auto);
+    world.set_child_space(node, Units::Stretch(1.0));
+    world.set_position_type(node, PositionType::SelfDirected);
 
     let child = world.add(Some(node));
-    world.set_width(child, Units::Pixels(100.0));
-    world.set_height(child, Units::Pixels(100.0));
+    world.set_width(child, Units::Pixels(300.0));
+    world.set_height(child, Units::Pixels(300.0));
+    // world.set_position_type(child, PositionType::SelfDirected);
     // world.set_min_width(child, Units::Stretch(1.0));
     // world.set_content_size(child, |_, width, height| {
     //     (100.0, 100.0)

--- a/src/node.rs
+++ b/src/node.rs
@@ -173,11 +173,21 @@ pub(crate) trait NodeExt: Node {
     }
 
     fn min_main(&self, store: &Self::Store, parent_layout_type: LayoutType) -> Units {
-        parent_layout_type.select_unwrap(store, |store| self.min_width(store), |store| self.min_height(store))
+        parent_layout_type.select_unwrap_default(
+            store,
+            |store| self.min_width(store),
+            |store| self.min_height(store),
+            Units::Pixels(0.0),
+        )
     }
 
     fn max_main(&self, store: &Self::Store, parent_layout_type: LayoutType) -> Units {
-        parent_layout_type.select_unwrap(store, |store| self.max_width(store), |store| self.max_height(store))
+        parent_layout_type.select_unwrap_default(
+            store,
+            |store| self.max_width(store),
+            |store| self.max_height(store),
+            Units::Pixels(f32::MAX),
+        )
     }
 
     fn cross(&self, store: &Self::Store, parent_layout_type: LayoutType) -> Units {
@@ -188,11 +198,21 @@ pub(crate) trait NodeExt: Node {
     }
 
     fn min_cross(&self, store: &Self::Store, parent_layout_type: LayoutType) -> Units {
-        parent_layout_type.select_unwrap(store, |store| self.min_height(store), |store| self.min_width(store))
+        parent_layout_type.select_unwrap_default(
+            store,
+            |store| self.min_height(store),
+            |store| self.min_width(store),
+            Units::Pixels(0.0),
+        )
     }
 
     fn max_cross(&self, store: &Self::Store, parent_layout_type: LayoutType) -> Units {
-        parent_layout_type.select_unwrap(store, |store| self.max_height(store), |store| self.max_width(store))
+        parent_layout_type.select_unwrap_default(
+            store,
+            |store| self.max_height(store),
+            |store| self.max_width(store),
+            Units::Pixels(f32::MAX),
+        )
     }
 
     fn main_before(&self, store: &Self::Store, parent_layout_type: LayoutType) -> Units {

--- a/src/types.rs
+++ b/src/types.rs
@@ -21,6 +21,20 @@ impl LayoutType {
             LayoutType::Column => second(s).unwrap_or_default(),
         }
     }
+
+    // Helper function for selecting between optional values depending on the layout type with specified default.
+    pub(crate) fn select_unwrap_default<T, S>(
+        &self,
+        s: S,
+        first: impl FnOnce(S) -> Option<T>,
+        second: impl FnOnce(S) -> Option<T>,
+        default: T,
+    ) -> T {
+        match self {
+            LayoutType::Row => first(s).unwrap_or(default),
+            LayoutType::Column => second(s).unwrap_or(default),
+        }
+    }
 }
 
 /// The position type determines whether a node will be positioned in-line with its siblings or out-of-line / independently of its siblings.

--- a/tests/size_constraints.rs
+++ b/tests/size_constraints.rs
@@ -193,3 +193,228 @@ fn min_width_percentage_width_auto() {
     assert_eq!(world.cache.bounds(node), Some(&Rect { posx: 0.0, posy: 0.0, width: 600.0, height: 100.0 }));
     assert_eq!(world.cache.bounds(node2), Some(&Rect { posx: 0.0, posy: 0.0, width: 200.0, height: 100.0 }));
 }
+
+#[test]
+fn min_width_auto() {
+    let mut world = World::default();
+
+    let root = world.add(None);
+    world.set_width(root, Units::Pixels(600.0));
+    world.set_height(root, Units::Pixels(600.0));
+    world.set_child_space(root, Units::Stretch(1.0));
+
+    let node = world.add(Some(root));
+    world.set_width(node, Units::Stretch(1.0));
+    world.set_height(node, Units::Stretch(1.0));
+    world.set_min_width(node, Units::Auto);
+
+    let node2 = world.add(Some(node));
+    world.set_width(node2, Units::Pixels(300.0));
+    world.set_height(node2, Units::Pixels(300.0));
+
+    root.layout(&mut world.cache, &world.tree, &world.store, &mut ());
+
+    assert_eq!(world.cache.bounds(node), Some(&Rect { posx: 150.0, posy: 200.0, width: 300.0, height: 200.0 }));
+    assert_eq!(world.cache.bounds(node2), Some(&Rect { posx: 0.0, posy: 0.0, width: 300.0, height: 300.0 }));
+}
+
+#[test]
+fn min_height_auto() {
+    let mut world = World::default();
+
+    let root = world.add(None);
+    world.set_width(root, Units::Pixels(600.0));
+    world.set_height(root, Units::Pixels(600.0));
+    world.set_child_space(root, Units::Stretch(1.0));
+
+    let node = world.add(Some(root));
+    world.set_width(node, Units::Stretch(1.0));
+    world.set_height(node, Units::Stretch(1.0));
+    world.set_min_height(node, Units::Auto);
+
+    let node2 = world.add(Some(node));
+    world.set_width(node2, Units::Pixels(300.0));
+    world.set_height(node2, Units::Pixels(300.0));
+
+    root.layout(&mut world.cache, &world.tree, &world.store, &mut ());
+
+    assert_eq!(world.cache.bounds(node), Some(&Rect { posx: 200.0, posy: 150.0, width: 200.0, height: 300.0 }));
+    assert_eq!(world.cache.bounds(node2), Some(&Rect { posx: 0.0, posy: 0.0, width: 300.0, height: 300.0 }));
+}
+
+#[test]
+fn min_size_auto() {
+    let mut world = World::default();
+
+    let root = world.add(None);
+    world.set_width(root, Units::Pixels(600.0));
+    world.set_height(root, Units::Pixels(600.0));
+    world.set_child_space(root, Units::Stretch(1.0));
+
+    let node = world.add(Some(root));
+    world.set_width(node, Units::Stretch(1.0));
+    world.set_height(node, Units::Stretch(1.0));
+    world.set_min_width(node, Units::Auto);
+    world.set_min_height(node, Units::Auto);
+
+    let node2 = world.add(Some(node));
+    world.set_width(node2, Units::Pixels(300.0));
+    world.set_height(node2, Units::Pixels(300.0));
+
+    root.layout(&mut world.cache, &world.tree, &world.store, &mut ());
+
+    assert_eq!(world.cache.bounds(node), Some(&Rect { posx: 150.0, posy: 150.0, width: 300.0, height: 300.0 }));
+    assert_eq!(world.cache.bounds(node2), Some(&Rect { posx: 0.0, posy: 0.0, width: 300.0, height: 300.0 }));
+}
+
+#[test]
+fn min_width_auto_self_directed() {
+    let mut world = World::default();
+
+    let root = world.add(None);
+    world.set_width(root, Units::Pixels(600.0));
+    world.set_height(root, Units::Pixels(600.0));
+    world.set_child_space(root, Units::Stretch(1.0));
+
+    let node = world.add(Some(root));
+    world.set_width(node, Units::Stretch(1.0));
+    world.set_height(node, Units::Stretch(1.0));
+    world.set_min_width(node, Units::Auto);
+    world.set_position_type(node, PositionType::SelfDirected);
+
+    let node2 = world.add(Some(node));
+    world.set_width(node2, Units::Pixels(300.0));
+    world.set_height(node2, Units::Pixels(300.0));
+
+    root.layout(&mut world.cache, &world.tree, &world.store, &mut ());
+
+    assert_eq!(world.cache.bounds(node), Some(&Rect { posx: 150.0, posy: 200.0, width: 300.0, height: 200.0 }));
+    assert_eq!(world.cache.bounds(node2), Some(&Rect { posx: 0.0, posy: 0.0, width: 300.0, height: 300.0 }));
+}
+
+#[test]
+fn min_height_auto_self_directed() {
+    let mut world = World::default();
+
+    let root = world.add(None);
+    world.set_width(root, Units::Pixels(600.0));
+    world.set_height(root, Units::Pixels(600.0));
+    world.set_child_space(root, Units::Stretch(1.0));
+
+    let node = world.add(Some(root));
+    world.set_width(node, Units::Stretch(1.0));
+    world.set_height(node, Units::Stretch(1.0));
+    world.set_min_height(node, Units::Auto);
+    world.set_position_type(node, PositionType::SelfDirected);
+
+    let node2 = world.add(Some(node));
+    world.set_width(node2, Units::Pixels(300.0));
+    world.set_height(node2, Units::Pixels(300.0));
+
+    root.layout(&mut world.cache, &world.tree, &world.store, &mut ());
+
+    assert_eq!(world.cache.bounds(node), Some(&Rect { posx: 200.0, posy: 150.0, width: 200.0, height: 300.0 }));
+    assert_eq!(world.cache.bounds(node2), Some(&Rect { posx: 0.0, posy: 0.0, width: 300.0, height: 300.0 }));
+}
+
+#[test]
+fn min_size_auto_self_directed() {
+    let mut world = World::default();
+
+    let root = world.add(None);
+    world.set_width(root, Units::Pixels(600.0));
+    world.set_height(root, Units::Pixels(600.0));
+    world.set_child_space(root, Units::Stretch(1.0));
+
+    let node = world.add(Some(root));
+    world.set_width(node, Units::Stretch(1.0));
+    world.set_height(node, Units::Stretch(1.0));
+    world.set_min_width(node, Units::Auto);
+    world.set_min_height(node, Units::Auto);
+    world.set_position_type(node, PositionType::SelfDirected);
+
+    let node2 = world.add(Some(node));
+    world.set_width(node2, Units::Pixels(300.0));
+    world.set_height(node2, Units::Pixels(300.0));
+
+    root.layout(&mut world.cache, &world.tree, &world.store, &mut ());
+
+    assert_eq!(world.cache.bounds(node), Some(&Rect { posx: 150.0, posy: 150.0, width: 300.0, height: 300.0 }));
+    assert_eq!(world.cache.bounds(node2), Some(&Rect { posx: 0.0, posy: 0.0, width: 300.0, height: 300.0 }));
+}
+
+#[test]
+fn min_width_auto_child_self_directed() {
+    let mut world = World::default();
+
+    let root = world.add(None);
+    world.set_width(root, Units::Pixels(600.0));
+    world.set_height(root, Units::Pixels(600.0));
+    world.set_child_space(root, Units::Stretch(1.0));
+
+    let node = world.add(Some(root));
+    world.set_width(node, Units::Stretch(1.0));
+    world.set_height(node, Units::Stretch(1.0));
+    world.set_min_width(node, Units::Auto);
+
+    let node2 = world.add(Some(node));
+    world.set_width(node2, Units::Pixels(300.0));
+    world.set_height(node2, Units::Pixels(300.0));
+    world.set_position_type(node2, PositionType::SelfDirected);
+
+    root.layout(&mut world.cache, &world.tree, &world.store, &mut ());
+
+    assert_eq!(world.cache.bounds(node), Some(&Rect { posx: 200.0, posy: 200.0, width: 200.0, height: 200.0 }));
+    assert_eq!(world.cache.bounds(node2), Some(&Rect { posx: 0.0, posy: 0.0, width: 300.0, height: 300.0 }));
+}
+
+#[test]
+fn min_height_auto_child_self_directed() {
+    let mut world = World::default();
+
+    let root = world.add(None);
+    world.set_width(root, Units::Pixels(600.0));
+    world.set_height(root, Units::Pixels(600.0));
+    world.set_child_space(root, Units::Stretch(1.0));
+
+    let node = world.add(Some(root));
+    world.set_width(node, Units::Stretch(1.0));
+    world.set_height(node, Units::Stretch(1.0));
+    world.set_min_height(node, Units::Auto);
+
+    let node2 = world.add(Some(node));
+    world.set_width(node2, Units::Pixels(300.0));
+    world.set_height(node2, Units::Pixels(300.0));
+    world.set_position_type(node2, PositionType::SelfDirected);
+
+    root.layout(&mut world.cache, &world.tree, &world.store, &mut ());
+
+    assert_eq!(world.cache.bounds(node), Some(&Rect { posx: 200.0, posy: 200.0, width: 200.0, height: 200.0 }));
+    assert_eq!(world.cache.bounds(node2), Some(&Rect { posx: 0.0, posy: 0.0, width: 300.0, height: 300.0 }));
+}
+
+#[test]
+fn min_size_auto_child_self_directed() {
+    let mut world = World::default();
+
+    let root = world.add(None);
+    world.set_width(root, Units::Pixels(600.0));
+    world.set_height(root, Units::Pixels(600.0));
+    world.set_child_space(root, Units::Stretch(1.0));
+
+    let node = world.add(Some(root));
+    world.set_width(node, Units::Stretch(1.0));
+    world.set_height(node, Units::Stretch(1.0));
+    world.set_min_width(node, Units::Auto);
+    world.set_min_height(node, Units::Auto);
+
+    let node2 = world.add(Some(node));
+    world.set_width(node2, Units::Pixels(300.0));
+    world.set_height(node2, Units::Pixels(300.0));
+    world.set_position_type(node2, PositionType::SelfDirected);
+
+    root.layout(&mut world.cache, &world.tree, &world.store, &mut ());
+
+    assert_eq!(world.cache.bounds(node), Some(&Rect { posx: 200.0, posy: 200.0, width: 200.0, height: 200.0 }));
+    assert_eq!(world.cache.bounds(node2), Some(&Rect { posx: 0.0, posy: 0.0, width: 300.0, height: 300.0 }));
+}


### PR DESCRIPTION
This allows nodes to have a min-size of their content. For example, a stretch node might have a size of 200x200 after computation, but let's say the node has a child that is 300x300 and a min-size (min-width & min-height) of `Auto`, then the node would instead get a size of 300x300. i.e. it can't be smaller than its contents.

To avoid a breaking change the default min-width/min-height is 0px rather than `Auto`.