### PR TITLE
Replace `clamp()` with `min().max()` to prevent panics when min > max

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -3,11 +3,11 @@ use crate::{LayoutType, Node};
 /// The `Cache` is a store which contains the computed size and position of nodes
 /// after a layout calculation.
 ///
-/// The `Node` associated type, which implements the [`Node`](crate::Node) trait, provides
+/// The `Node` associated type, which implements the [`Node`] trait, provides
 /// a [`CacheKey`](crate::Node::CacheKey) associated type which can be used as key for storage types
 /// within the cache if the `Node` type itself cannot be used. For example, as the key to a hashmap/slotmap.
 pub trait Cache {
-    /// A type which represents a layout node and implements the [`Node`](crate::Node) trait.
+    /// A type which represents a layout node and implements the [`Node`] trait.
     type Node: Node;
     /// Returns the cached width of the given node.
     fn width(&self, node: &Self::Node) -> f32;

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -152,7 +152,7 @@ where
     }
 
     // Apply main-axis size constraints for pixels and percentage.
-    computed_main = computed_main.clamp(min_main, max_main);
+    computed_main = computed_main.min(max_main).max(min_main);
 
     // TODO: Figure out how to constrain content size on cross axis.
 
@@ -348,7 +348,7 @@ where
         min_cross = cross_max + border_cross_before + border_cross_after
     }
 
-    parent_cross = parent_cross.clamp(min_cross, max_cross);
+    parent_cross = parent_cross.min(max_cross).max(min_cross);
 
     // Compute flexible space and size on the cross-axis for parent-directed children.
     for (index, child) in children
@@ -453,7 +453,7 @@ where
                     }
                 }
 
-                let clamped = actual_cross.clamp(item.min, item.max);
+                let clamped = actual_cross.min(item.max).max(item.min);
                 item.violation = clamped - actual_cross;
                 total_violation += item.violation;
 
@@ -491,7 +491,7 @@ where
         min_main = parent_main.max(main_sum) + border_main_before + border_main_after
     }
 
-    parent_main = parent_main.clamp(min_main, max_main);
+    parent_main = parent_main.min(max_main).max(min_main);
 
     // Compute flexible space and size on the main axis for parent-directed children.
     if !main_axis.is_empty() {
@@ -521,7 +521,7 @@ where
                     }
                 }
 
-                let clamped = actual_main.clamp(item.min, item.max);
+                let clamped = actual_main.min(item.max).max(item.min);
                 item.violation = clamped - actual_main;
                 total_violation += item.violation;
                 item.computed = clamped;
@@ -745,7 +745,7 @@ where
                     child.main = child_size.main;
                 }
 
-                let clamped = actual_cross.clamp(item.min, item.max);
+                let clamped = actual_cross.min(item.max).max(item.min);
                 item.violation = clamped - actual_cross;
                 total_violation += item.violation;
 
@@ -865,7 +865,7 @@ where
                     }
                 }
 
-                let clamped = actual_main.clamp(item.min, item.max);
+                let clamped = actual_main.min(item.max).max(item.min);
                 item.violation = clamped - actual_main;
                 total_violation += item.violation;
                 item.computed = clamped;
@@ -976,7 +976,7 @@ where
             for item in cross_axis.iter_mut().filter(|item| !item.frozen) {
                 let actual_cross = (item.factor * child_cross_free_space / cross_flex_sum).round();
 
-                let clamped = actual_cross.clamp(item.min, item.max);
+                let clamped = actual_cross.min(item.max).max(item.min);
                 item.violation = clamped - actual_cross;
                 total_violation += item.violation;
 
@@ -1059,8 +1059,8 @@ where
         }
     }
 
-    computed_main = computed_main.clamp(min_main, max_main);
-    computed_cross = computed_cross.clamp(min_cross, max_cross);
+    computed_main = computed_main.min(max_main).max(min_main);
+    computed_cross = computed_cross.min(max_cross).max(min_cross);
 
     // Return the computed size, propagating it back up the tree.
     Size { main: computed_main, cross: computed_cross }

--- a/src/node.rs
+++ b/src/node.rs
@@ -20,7 +20,7 @@ pub trait Node: Sized {
     type ChildIter<'t>: Iterator<Item = &'t Self>
     where
         Self: 't;
-    /// A type representing a key to store and retrieve values from the [`Cache`](crate::Cache).
+    /// A type representing a key to store and retrieve values from the [`Cache`].
     type CacheKey;
     /// A type representing a context which can be used to save/load state when computing [content size](crate::Node::content_size).
     /// For example, a `TextContext` which could be used to measure (and cache) the size of text, which could

--- a/src/types.rs
+++ b/src/types.rs
@@ -90,11 +90,12 @@ impl Units {
     pub fn to_px_clamped(&self, parent_value: f32, default: f32, min: Units, max: Units) -> f32 {
         let min = min.to_px(parent_value, f32::MIN);
         let max = max.to_px(parent_value, f32::MAX);
+
         match self {
-            Units::Pixels(pixels) => pixels.clamp(min, max),
-            Units::Percentage(percentage) => ((percentage / 100.0) * parent_value).clamp(min, max),
-            Units::Stretch(_) => default.clamp(min, max),
-            Units::Auto => default.clamp(min, max),
+            Units::Pixels(pixels) => pixels.min(max).max(min),
+            Units::Percentage(percentage) => ((percentage / 100.0) * parent_value).min(max).max(min),
+            Units::Stretch(_) => default.min(max).max(min),
+            Units::Auto => default.min(max).max(min),
         }
     }
 


### PR DESCRIPTION
Preferences min size over max size in cases where min > max