### PR TITLE
Fix RTL flipping for absolute positioned children

### DIFF
--- a/src/layout.rs
+++ b/src/layout.rs
@@ -1032,13 +1032,12 @@ where
 
     // Position absolute children.
     for abs_child in &abs_items {
-        let (child_main_before, child_main_after) = if layout_type == LayoutType::Row
-            && node.direction(store).unwrap_or_default() == Direction::RightToLeft
-        {
-            (abs_child.node.main_after(store, layout_type), abs_child.node.main_before(store, layout_type))
-        } else {
-            (abs_child.node.main_before(store, layout_type), abs_child.node.main_after(store, layout_type))
-        };
+        let (child_main_before, child_main_after) =
+            if layout_type == LayoutType::Row && node.direction(store).unwrap_or_default() == Direction::RightToLeft {
+                (abs_child.node.main_after(store, layout_type), abs_child.node.main_before(store, layout_type))
+            } else {
+                (abs_child.node.main_before(store, layout_type), abs_child.node.main_after(store, layout_type))
+            };
         let (child_cross_before, child_cross_after) = if layout_type == LayoutType::Column
             && node.direction(store).unwrap_or_default() == Direction::RightToLeft
         {

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -1032,13 +1032,20 @@ where
 
     // Position absolute children.
     for abs_child in &abs_items {
-        let (child_main_before, child_main_after) = if is_inline_rtl {
+        let (child_main_before, child_main_after) = if layout_type == LayoutType::Row
+            && node.direction(store).unwrap_or_default() == Direction::RightToLeft
+        {
             (abs_child.node.main_after(store, layout_type), abs_child.node.main_before(store, layout_type))
         } else {
             (abs_child.node.main_before(store, layout_type), abs_child.node.main_after(store, layout_type))
         };
-        let child_cross_before = abs_child.node.cross_before(store, layout_type);
-        let child_cross_after = abs_child.node.cross_after(store, layout_type);
+        let (child_cross_before, child_cross_after) = if layout_type == LayoutType::Column
+            && node.direction(store).unwrap_or_default() == Direction::RightToLeft
+        {
+            (abs_child.node.cross_after(store, layout_type), abs_child.node.cross_before(store, layout_type))
+        } else {
+            (abs_child.node.cross_before(store, layout_type), abs_child.node.cross_after(store, layout_type))
+        };
 
         let pma = abs_avail_main;
         let pca = abs_avail_cross;

--- a/tests/absolute.rs
+++ b/tests/absolute.rs
@@ -353,3 +353,95 @@ fn rtl_absolute_in_column_only_flips_horizontal_offsets() {
     // RTL mirrors only horizontal offsets, so left becomes trailing while top is unchanged.
     assert_eq!(world.cache.bounds(node), Some(&Rect { posx: 480.0, posy: 10.0, width: 100.0, height: 80.0 }));
 }
+
+#[test]
+fn rtl_absolute_in_column_bottom_offset_is_not_flipped() {
+    let mut world = World::default();
+
+    let root = world.add(None);
+    world.set_layout_type(root, LayoutType::Column);
+    world.set_direction(root, Direction::RightToLeft);
+    world.set_width(root, Units::Pixels(600.0));
+    world.set_height(root, Units::Pixels(400.0));
+
+    let node = world.add(Some(root));
+    world.set_position_type(node, PositionType::Absolute);
+    world.set_width(node, Units::Pixels(100.0));
+    world.set_height(node, Units::Pixels(80.0));
+    world.set_left(node, Units::Pixels(20.0));
+    world.set_bottom(node, Units::Pixels(10.0));
+
+    root.layout(&mut world.cache, &world.tree, &world.store, &mut ());
+
+    // RTL mirrors only horizontal offsets, so left becomes trailing while bottom remains bottom.
+    assert_eq!(world.cache.bounds(node), Some(&Rect { posx: 480.0, posy: 310.0, width: 100.0, height: 80.0 }));
+}
+
+#[test]
+fn rtl_absolute_stretch_height_in_column_uses_top_and_bottom_without_flip() {
+    let mut world = World::default();
+
+    let root = world.add(None);
+    world.set_layout_type(root, LayoutType::Column);
+    world.set_direction(root, Direction::RightToLeft);
+    world.set_width(root, Units::Pixels(600.0));
+    world.set_height(root, Units::Pixels(400.0));
+
+    let node = world.add(Some(root));
+    world.set_position_type(node, PositionType::Absolute);
+    world.set_width(node, Units::Pixels(100.0));
+    world.set_height(node, Units::Stretch(1.0));
+    world.set_left(node, Units::Pixels(20.0));
+    world.set_top(node, Units::Pixels(10.0));
+    world.set_bottom(node, Units::Pixels(30.0));
+
+    root.layout(&mut world.cache, &world.tree, &world.store, &mut ());
+
+    assert_eq!(world.cache.bounds(node), Some(&Rect { posx: 480.0, posy: 10.0, width: 100.0, height: 360.0 }));
+}
+
+#[test]
+fn rtl_absolute_in_row_only_flips_horizontal_offsets() {
+    let mut world = World::default();
+
+    let root = world.add(None);
+    world.set_layout_type(root, LayoutType::Row);
+    world.set_direction(root, Direction::RightToLeft);
+    world.set_width(root, Units::Pixels(600.0));
+    world.set_height(root, Units::Pixels(400.0));
+
+    let node = world.add(Some(root));
+    world.set_position_type(node, PositionType::Absolute);
+    world.set_width(node, Units::Pixels(100.0));
+    world.set_height(node, Units::Pixels(80.0));
+    world.set_left(node, Units::Pixels(20.0));
+    world.set_top(node, Units::Pixels(10.0));
+
+    root.layout(&mut world.cache, &world.tree, &world.store, &mut ());
+
+    // RTL mirrors only horizontal offsets, so left becomes trailing while top is unchanged.
+    assert_eq!(world.cache.bounds(node), Some(&Rect { posx: 480.0, posy: 10.0, width: 100.0, height: 80.0 }));
+}
+
+#[test]
+fn rtl_absolute_bottom_offset_is_not_flipped() {
+    let mut world = World::default();
+
+    let root = world.add(None);
+    world.set_layout_type(root, LayoutType::Row);
+    world.set_direction(root, Direction::RightToLeft);
+    world.set_width(root, Units::Pixels(600.0));
+    world.set_height(root, Units::Pixels(400.0));
+
+    let node = world.add(Some(root));
+    world.set_position_type(node, PositionType::Absolute);
+    world.set_width(node, Units::Pixels(100.0));
+    world.set_height(node, Units::Pixels(80.0));
+    world.set_left(node, Units::Pixels(20.0));
+    world.set_bottom(node, Units::Pixels(10.0));
+
+    root.layout(&mut world.cache, &world.tree, &world.store, &mut ());
+
+    // RTL mirrors only horizontal offsets, so left becomes trailing while bottom remains bottom.
+    assert_eq!(world.cache.bounds(node), Some(&Rect { posx: 480.0, posy: 310.0, width: 100.0, height: 80.0 }));
+}

--- a/tests/wrap.rs
+++ b/tests/wrap.rs
@@ -110,6 +110,30 @@ fn wrap_column_basic() {
 }
 
 #[test]
+fn wrap_column_rtl_absolute_only_flips_horizontal_offsets() {
+    let mut world = World::default();
+
+    let root = world.add(None);
+    world.set_width(root, Units::Pixels(200.0));
+    world.set_height(root, Units::Pixels(250.0));
+    world.set_layout_type(root, LayoutType::Column);
+    world.set_wrap(root, LayoutWrap::Wrap);
+    world.set_direction(root, Direction::RightToLeft);
+
+    let node = world.add(Some(root));
+    world.set_position_type(node, PositionType::Absolute);
+    world.set_width(node, Units::Pixels(80.0));
+    world.set_height(node, Units::Pixels(100.0));
+    world.set_left(node, Units::Pixels(20.0));
+    world.set_top(node, Units::Pixels(10.0));
+
+    root.layout(&mut world.cache, &world.tree, &world.store, &mut ());
+
+    // RTL should mirror only the horizontal offset in a wrapped column.
+    assert_eq!(world.cache.bounds(node), Some(&Rect { posx: 100.0, posy: 10.0, width: 80.0, height: 100.0 }));
+}
+
+#[test]
 fn wrap_row_with_stretch() {
     // Test row wrapping with stretch items filling available space on each line
     let mut world = World::default();


### PR DESCRIPTION
Adjust RTL mirroring logic when positioning absolute children: flip main offsets only for row layouts in RTL, and flip cross offsets only for column layouts in RTL (by swapping main_before/main_after and cross_before/cross_after conditionally). Add unit tests in tests/absolute.rs and tests/wrap.rs to cover RTL behavior for left/top/bottom offsets, stretch heights, and wrapped columns to prevent regressions.