### PR TITLE
Add aspect ratio sizing support to layout

### DIFF
--- a/ecs/src/implementations.rs
+++ b/ecs/src/implementations.rs
@@ -59,6 +59,10 @@ impl Node for Entity {
         store.height.get(*self).copied()
     }
 
+    fn aspect_ratio(&self, store: &Store) -> Option<f32> {
+        store.aspect_ratio.get(*self).copied()
+    }
+
     fn left(&self, store: &Store) -> Option<Units> {
         store.left.get(*self).copied()
     }

--- a/ecs/src/store.rs
+++ b/ecs/src/store.rs
@@ -31,6 +31,7 @@ pub struct Store {
 
     pub width: SecondaryMap<Entity, Units>,
     pub height: SecondaryMap<Entity, Units>,
+    pub aspect_ratio: SecondaryMap<Entity, f32>,
     pub min_width: SecondaryMap<Entity, Units>,
     pub max_width: SecondaryMap<Entity, Units>,
     pub min_height: SecondaryMap<Entity, Units>,
@@ -74,6 +75,7 @@ impl Store {
         self.bottom.remove(entity);
         self.width.remove(entity);
         self.height.remove(entity);
+        self.aspect_ratio.remove(entity);
         self.min_width.remove(entity);
         self.max_width.remove(entity);
         self.min_height.remove(entity);
@@ -108,6 +110,7 @@ impl Store {
         self.bottom.clear();
         self.width.clear();
         self.height.clear();
+        self.aspect_ratio.clear();
         self.min_width.clear();
         self.max_width.clear();
         self.min_height.clear();

--- a/ecs/src/world.rs
+++ b/ecs/src/world.rs
@@ -111,6 +111,11 @@ impl World {
         self.store.height.insert(entity, value);
     }
 
+    /// Set the preferred aspect ratio (`width / height`) of the given entity.
+    pub fn set_aspect_ratio(&mut self, entity: Entity, value: f32) {
+        self.store.aspect_ratio.insert(entity, value);
+    }
+
     /// Set the desired left space of the given entity.
     pub fn set_left(&mut self, entity: Entity, value: Units) {
         self.store.left.insert(entity, value);

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -75,6 +75,7 @@ fn same_f32(a: f32, b: f32) -> bool {
     a.to_bits() == b.to_bits()
 }
 
+#[allow(clippy::too_many_arguments)]
 fn clamp_with_aspect_ratio(
     parent_layout_type: LayoutType,
     aspect_ratio: Option<f32>,

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -75,6 +75,69 @@ fn same_f32(a: f32, b: f32) -> bool {
     a.to_bits() == b.to_bits()
 }
 
+fn clamp_with_aspect_ratio(
+    parent_layout_type: LayoutType,
+    aspect_ratio: Option<f32>,
+    main_is_auto: bool,
+    cross_is_auto: bool,
+    min_main: f32,
+    max_main: f32,
+    min_cross: f32,
+    max_cross: f32,
+    computed_main: &mut f32,
+    computed_cross: &mut f32,
+) {
+    *computed_main = computed_main.max(min_main).min(max_main);
+    *computed_cross = computed_cross.max(min_cross).min(max_cross);
+
+    let Some(ratio) = aspect_ratio else {
+        return;
+    };
+
+    if !ratio.is_finite() || ratio <= 0.0 {
+        return;
+    }
+
+    let derive_main_from_cross = |cross: f32| match parent_layout_type {
+        LayoutType::Row | LayoutType::Overlay | LayoutType::Grid => cross * ratio,
+        LayoutType::Column => cross / ratio,
+    };
+
+    let derive_cross_from_main = |main: f32| match parent_layout_type {
+        LayoutType::Row | LayoutType::Overlay | LayoutType::Grid => main / ratio,
+        LayoutType::Column => main * ratio,
+    };
+
+    match (main_is_auto, cross_is_auto) {
+        (true, false) => {
+            *computed_main = derive_main_from_cross(*computed_cross);
+        }
+
+        (false, true) => {
+            *computed_cross = derive_cross_from_main(*computed_main);
+        }
+
+        (true, true) => {
+            if *computed_main > 0.0 {
+                *computed_cross = derive_cross_from_main(*computed_main);
+            } else if *computed_cross > 0.0 {
+                *computed_main = derive_main_from_cross(*computed_cross);
+            } else if min_main > 0.0 {
+                *computed_main = min_main;
+                *computed_cross = derive_cross_from_main(*computed_main);
+            } else if min_cross > 0.0 {
+                *computed_cross = min_cross;
+                *computed_main = derive_main_from_cross(*computed_cross);
+            }
+        }
+
+        (false, false) => {}
+    }
+
+    *computed_main = computed_main.max(min_main).min(max_main);
+    *computed_cross = computed_cross.max(min_cross).min(max_cross);
+}
+
 fn alignment_fractions(alignment: Alignment) -> (f32, f32) {
     // Convert alignment into normalized horizontal/vertical fractions in [0, 1].
     // These fractions are later multiplied by available free space.
@@ -1186,6 +1249,7 @@ where
     // The desired main-axis and cross-axis sizes of the node.
     let main = node.main(store, parent_layout_type);
     let cross = node.cross(store, parent_layout_type);
+    let aspect_ratio = node.aspect_ratio(store).filter(|ratio| ratio.is_finite() && *ratio > 0.0);
 
     let mut min_main = if main.is_stretch() {
         DEFAULT_MIN
@@ -1258,8 +1322,18 @@ where
         }
     }
 
-    computed_main = computed_main.max(min_main).min(max_main);
-    computed_cross = computed_cross.max(min_cross).min(max_cross);
+    clamp_with_aspect_ratio(
+        parent_layout_type,
+        aspect_ratio,
+        main.is_auto(),
+        cross.is_auto(),
+        min_main,
+        max_main,
+        min_cross,
+        max_cross,
+        &mut computed_main,
+        &mut computed_cross,
+    );
 
     if layout_type == LayoutType::Grid {
         return layout_grid(node, parent_layout_type, computed_main, computed_cross, cache, tree, store, sublayout);
@@ -1432,8 +1506,18 @@ where
         }
     }
 
-    computed_main = computed_main.max(min_main).min(max_main);
-    computed_cross = computed_cross.max(min_cross).min(max_cross);
+    clamp_with_aspect_ratio(
+        parent_layout_type,
+        aspect_ratio,
+        main.is_auto(),
+        cross.is_auto(),
+        min_main,
+        max_main,
+        min_cross,
+        max_cross,
+        &mut computed_main,
+        &mut computed_cross,
+    );
 
     let (mut parent_main, mut parent_cross) = if parent_layout_type == layout_type {
         (computed_main, computed_cross)
@@ -1514,8 +1598,18 @@ where
         }
     }
 
-    computed_main = computed_main.max(min_main).min(max_main);
-    computed_cross = computed_cross.max(min_cross).min(max_cross);
+    clamp_with_aspect_ratio(
+        parent_layout_type,
+        aspect_ratio,
+        main.is_auto(),
+        cross.is_auto(),
+        min_main,
+        max_main,
+        min_cross,
+        max_cross,
+        &mut computed_main,
+        &mut computed_cross,
+    );
 
     // Compute flexible space and size on the main axis for relative children.
     if !main_axis.is_empty() {
@@ -1666,8 +1760,18 @@ where
         }
     }
 
-    computed_main = computed_main.max(min_main).min(max_main);
-    computed_cross = computed_cross.max(min_cross).min(max_cross);
+    clamp_with_aspect_ratio(
+        parent_layout_type,
+        aspect_ratio,
+        main.is_auto(),
+        cross.is_auto(),
+        min_main,
+        max_main,
+        min_cross,
+        max_cross,
+        &mut computed_main,
+        &mut computed_cross,
+    );
 
     let (mut parent_main, mut parent_cross) = if parent_layout_type == layout_type {
         (computed_main, computed_cross)

--- a/src/node.rs
+++ b/src/node.rs
@@ -134,6 +134,13 @@ pub trait Node: Sized {
     /// Returns the desired height of the node.
     fn height(&self, store: &Self::Store) -> Option<Units>;
 
+    /// Returns an optional preferred aspect ratio (`width / height`) for the node.
+    ///
+    /// The layout algorithm may use this to derive an auto axis from the resolved axis.
+    fn aspect_ratio(&self, _store: &Self::Store) -> Option<f32> {
+        None
+    }
+
     /// Returns the desired left-side space of the node.
     fn left(&self, store: &Self::Store) -> Option<Units>;
 

--- a/tests/aspect_ratio.rs
+++ b/tests/aspect_ratio.rs
@@ -1,0 +1,129 @@
+use morphorm::*;
+use morphorm_ecs::*;
+
+#[test]
+fn aspect_ratio_leaf_derives_height_from_width() {
+    let mut world = World::default();
+
+    let root = world.add(None);
+    world.set_width(root, Units::Pixels(600.0));
+    world.set_height(root, Units::Pixels(600.0));
+    world.set_layout_type(root, LayoutType::Row);
+    world.set_alignment(root, Alignment::TopLeft);
+
+    let node = world.add(Some(root));
+    world.set_width(node, Units::Pixels(300.0));
+    world.set_height(node, Units::Auto);
+    world.set_aspect_ratio(node, 2.0);
+
+    root.layout(&mut world.cache, &world.tree, &world.store, &mut ());
+
+    assert_eq!(world.cache.bounds(node), Some(&Rect { posx: 0.0, posy: 0.0, width: 300.0, height: 150.0 }));
+}
+
+#[test]
+fn aspect_ratio_leaf_derives_width_from_height() {
+    let mut world = World::default();
+
+    let root = world.add(None);
+    world.set_width(root, Units::Pixels(600.0));
+    world.set_height(root, Units::Pixels(600.0));
+    world.set_layout_type(root, LayoutType::Row);
+    world.set_alignment(root, Alignment::TopLeft);
+
+    let node = world.add(Some(root));
+    world.set_width(node, Units::Auto);
+    world.set_height(node, Units::Pixels(120.0));
+    world.set_aspect_ratio(node, 1.5);
+
+    root.layout(&mut world.cache, &world.tree, &world.store, &mut ());
+
+    assert_eq!(world.cache.bounds(node), Some(&Rect { posx: 0.0, posy: 0.0, width: 180.0, height: 120.0 }));
+}
+
+#[test]
+fn aspect_ratio_leaf_column_parent_axis_conversion() {
+    let mut world = World::default();
+
+    let root = world.add(None);
+    world.set_width(root, Units::Pixels(600.0));
+    world.set_height(root, Units::Pixels(600.0));
+    world.set_layout_type(root, LayoutType::Column);
+    world.set_alignment(root, Alignment::TopLeft);
+
+    let node = world.add(Some(root));
+    world.set_width(node, Units::Auto);
+    world.set_height(node, Units::Pixels(300.0));
+    world.set_aspect_ratio(node, 2.0);
+
+    root.layout(&mut world.cache, &world.tree, &world.store, &mut ());
+
+    assert_eq!(world.cache.bounds(node), Some(&Rect { posx: 0.0, posy: 0.0, width: 600.0, height: 300.0 }));
+}
+
+#[test]
+fn aspect_ratio_container_both_auto_with_children() {
+    let mut world = World::default();
+
+    let root = world.add(None);
+    world.set_width(root, Units::Pixels(600.0));
+    world.set_height(root, Units::Pixels(600.0));
+    world.set_layout_type(root, LayoutType::Row);
+    world.set_alignment(root, Alignment::TopLeft);
+
+    let container = world.add(Some(root));
+    world.set_width(container, Units::Auto);
+    world.set_height(container, Units::Auto);
+    world.set_aspect_ratio(container, 1.0);
+
+    let child = world.add(Some(container));
+    world.set_width(child, Units::Pixels(200.0));
+    world.set_height(child, Units::Pixels(100.0));
+
+    root.layout(&mut world.cache, &world.tree, &world.store, &mut ());
+
+    assert_eq!(world.cache.bounds(container), Some(&Rect { posx: 0.0, posy: 0.0, width: 200.0, height: 200.0 }));
+    assert_eq!(world.cache.bounds(child), Some(&Rect { posx: 0.0, posy: 0.0, width: 200.0, height: 100.0 }));
+}
+
+#[test]
+fn aspect_ratio_min_width_can_override_ratio_result() {
+    let mut world = World::default();
+
+    let root = world.add(None);
+    world.set_width(root, Units::Pixels(600.0));
+    world.set_height(root, Units::Pixels(600.0));
+    world.set_layout_type(root, LayoutType::Row);
+    world.set_alignment(root, Alignment::TopLeft);
+
+    let node = world.add(Some(root));
+    world.set_width(node, Units::Auto);
+    world.set_height(node, Units::Pixels(100.0));
+    world.set_aspect_ratio(node, 2.0);
+    world.set_min_width(node, Units::Pixels(250.0));
+
+    root.layout(&mut world.cache, &world.tree, &world.store, &mut ());
+
+    assert_eq!(world.cache.bounds(node), Some(&Rect { posx: 0.0, posy: 0.0, width: 250.0, height: 100.0 }));
+}
+
+#[test]
+fn aspect_ratio_max_height_can_override_ratio_result() {
+    let mut world = World::default();
+
+    let root = world.add(None);
+    world.set_width(root, Units::Pixels(600.0));
+    world.set_height(root, Units::Pixels(600.0));
+    world.set_layout_type(root, LayoutType::Row);
+    world.set_alignment(root, Alignment::TopLeft);
+
+    let node = world.add(Some(root));
+    world.set_width(node, Units::Pixels(400.0));
+    world.set_height(node, Units::Auto);
+    world.set_aspect_ratio(node, 2.0);
+    world.set_max_height(node, Units::Pixels(100.0));
+
+    root.layout(&mut world.cache, &world.tree, &world.store, &mut ());
+
+    assert_eq!(world.cache.bounds(node), Some(&Rect { posx: 0.0, posy: 0.0, width: 400.0, height: 100.0 }));
+}


### PR DESCRIPTION
Introduce optional `aspect_ratio` (`width / height`) on nodes and wire it through the ECS store/world API. The layout engine now derives auto main/cross sizes from the resolved axis while respecting parent layout orientation, then reapplies min/max constraints so limits can override ratio-derived sizes. Added focused tests for leaf/container behavior, row/column axis conversion, and min/max constraint interactions.